### PR TITLE
feat: Swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")
+
 	// testcontainers
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 
@@ -46,3 +48,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+tasks.bootBuildImage.createdDate = "now"
+
+springBoot.buildInfo { properties {} }

--- a/src/main/java/kr/co/webee/presentation/annotation/ApiDocsErrorType.java
+++ b/src/main/java/kr/co/webee/presentation/annotation/ApiDocsErrorType.java
@@ -1,0 +1,17 @@
+package kr.co.webee.presentation.annotation;
+
+import kr.co.webee.common.error.ErrorType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 컨트롤러 메서드에 대한 API 문서화 시 에러 타입을 명시하는 어노테이션입니다.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiDocsErrorType {
+    ErrorType[] value();
+}

--- a/src/main/java/kr/co/webee/presentation/config/SwaggerConfig.java
+++ b/src/main/java/kr/co/webee/presentation/config/SwaggerConfig.java
@@ -1,0 +1,114 @@
+package kr.co.webee.presentation.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import kr.co.webee.presentation.annotation.ApiDocsErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.security.config.Elements.JWT;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+@RequiredArgsConstructor
+@Configuration
+public class SwaggerConfig {
+    private final BuildProperties buildProperties;
+
+    @Bean
+    OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name(JWT)
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .scheme("Bearer")
+                .bearerFormat(JWT)
+                .name(AUTHORIZATION)
+                .description("JWT 토큰을 입력해주세요 (Bearer 제외)");
+
+        return new OpenAPI()
+                .info(info())
+                .addSecurityItem(new SecurityRequirement().addList(JWT))
+                .components(new Components().addSecuritySchemes(JWT, securityScheme));
+    }
+
+    @Bean
+    ModelResolver modelResolver(ObjectMapper objectMapper) { // Load formats from ObjectMapper
+        return new ModelResolver(objectMapper);
+    }
+
+    @Bean
+    OperationCustomizer successResponseBodyWrapper() {
+        return (operation, handlerMethod) -> {
+            if (!operation.getResponses().containsKey("200")) {
+                return operation;
+            }
+            Content content = operation.getResponses().get("200").getContent();
+            if (content == null) {
+                return operation;
+            }
+            content.forEach((mediaTypeKey, mediaType) -> {
+                Schema<?> originalSchema = mediaType.getSchema();
+                Schema<?> wrappedSchema = new Schema<>();
+                wrappedSchema.addProperty("code", new StringSchema().example("200"));
+                wrappedSchema.addProperty("message", new StringSchema().example("요청이 성공하였습니다."));
+                wrappedSchema.addProperty("data", originalSchema);
+                mediaType.setSchema(wrappedSchema);
+            });
+            return operation;
+        };
+    }
+
+    @Bean
+    OperationCustomizer apiErrorTypeCustomizer() {
+        return (operation, handlerMethod) -> {
+            ApiDocsErrorType apiErrorType = handlerMethod.getMethodAnnotation(ApiDocsErrorType.class);
+            if (apiErrorType == null) {
+                return operation;
+            }
+
+            Stream.of(apiErrorType.value())
+                    .sorted(Comparator.comparingInt(t -> t.getHttpStatus().value()))
+                    .forEach(type -> {
+                        Content content = new Content().addMediaType(APPLICATION_JSON_VALUE,
+                                new MediaType()
+                                        .schema(new Schema<>()
+                                                .addProperty("code", new StringSchema().example(type.getHttpStatus().value() + ""))
+                                                .addProperty("message", new StringSchema().example(type.getMessage()))
+                                                .addProperty("data", new StringSchema().example("null"))
+                                        ));
+
+                        operation.getResponses().put(
+                                type.getHttpStatus().value() + " " + type.name(),
+                                new ApiResponse().description(type.getMessage()).content(content));
+                    });
+            return operation;
+        };
+    }
+
+    private Info info() {
+        return new Info()
+                .title("WeBee API")
+                .description("API 명세 문서 <br> 빌드 일자: " + buildProperties.getTime().atZone(ZoneId.of("Asia/Seoul"))
+                        + "<br> 실행 일자: " + ZonedDateTime.now())
+                .version(buildProperties.getVersion());
+    }
+}


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #7

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- Swagger 설정을 추가합니다.
  - Spring security가 설정되어 있어서 지금은 swagger 문서를 볼 수 없습니다.
  - Spring security 설정에서 `"/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**"` 을 `permitAll()` 설정하면 될 것 같아요

## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
