### PR TITLE
fix: 사용자 재배 작물 정보 DTO 수정

### DIFF
--- a/src/main/java/kr/co/webee/application/profile/crop/service/UserCropService.java
+++ b/src/main/java/kr/co/webee/application/profile/crop/service/UserCropService.java
@@ -11,6 +11,7 @@ import kr.co.webee.domain.user.entity.User;
 import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.infrastructure.geocoding.client.GeocodingClient;
 import kr.co.webee.presentation.profile.crop.dto.request.UserCropRequest;
+import kr.co.webee.presentation.profile.crop.dto.response.UserCropCreateResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropDetailResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropListResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +28,7 @@ public class UserCropService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Map<String,Long> createUserCrop(UserCropRequest request, Long userId) {
+    public UserCropCreateResponse createUserCrop(UserCropRequest request, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
 
@@ -37,7 +37,7 @@ public class UserCropService {
         UserCrop userCrop = request.toEntity(coordinates, user);
         userCropRepository.save(userCrop);
 
-        return Map.of("userCropId",userCrop.getId());
+        return UserCropCreateResponse.of(userCrop.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/webee/application/profile/crop/service/UserCropService.java
+++ b/src/main/java/kr/co/webee/application/profile/crop/service/UserCropService.java
@@ -10,7 +10,8 @@ import kr.co.webee.domain.profile.crop.repository.UserCropRepository;
 import kr.co.webee.domain.user.entity.User;
 import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.infrastructure.geocoding.client.GeocodingClient;
-import kr.co.webee.presentation.profile.crop.dto.request.UserCropRequest;
+import kr.co.webee.presentation.profile.crop.dto.request.UserCropCreateRequest;
+import kr.co.webee.presentation.profile.crop.dto.request.UserCropUpdateRequest;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropCreateResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropDetailResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropListResponse;
@@ -28,7 +29,7 @@ public class UserCropService {
     private final UserRepository userRepository;
 
     @Transactional
-    public UserCropCreateResponse createUserCrop(UserCropRequest request, Long userId) {
+    public UserCropCreateResponse createUserCrop(UserCropCreateRequest request, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
 
@@ -58,7 +59,7 @@ public class UserCropService {
     }
 
     @Transactional
-    public void updateUserCrop(Long userCropId, UserCropRequest request, Long userId) {
+    public void updateUserCrop(Long userCropId, UserCropUpdateRequest request, Long userId) {
         UserCrop userCrop = userCropRepository.findById(userCropId)
                 .orElseThrow(() -> new EntityNotFoundException("User Crop not found"));
 

--- a/src/main/java/kr/co/webee/presentation/profile/crop/api/UserCropApi.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/api/UserCropApi.java
@@ -7,7 +7,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.webee.presentation.annotation.UserId;
-import kr.co.webee.presentation.profile.crop.dto.request.UserCropRequest;
+import kr.co.webee.presentation.profile.crop.dto.request.UserCropCreateRequest;
+import kr.co.webee.presentation.profile.crop.dto.request.UserCropUpdateRequest;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropCreateResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropDetailResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropListResponse;
@@ -28,7 +29,7 @@ public interface UserCropApi {
     })
     UserCropCreateResponse createUserCrop(
             @Parameter(description = "등록할 사용자 재배 작물 정보", required = true)
-            @RequestBody @Valid UserCropRequest request,
+            @RequestBody @Valid UserCropCreateRequest request,
 
             @Parameter(hidden = true)
             @UserId Long userId
@@ -73,7 +74,7 @@ public interface UserCropApi {
             @PathVariable Long userCropId,
 
             @Parameter(description = "수정할 사용자 재배 작물 정보", required = true)
-            @RequestBody @Valid UserCropRequest request,
+            @RequestBody @Valid UserCropUpdateRequest request,
 
             @Parameter(hidden = true)
             @UserId Long userId

--- a/src/main/java/kr/co/webee/presentation/profile/crop/api/UserCropApi.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/api/UserCropApi.java
@@ -8,13 +8,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.webee.presentation.annotation.UserId;
 import kr.co.webee.presentation.profile.crop.dto.request.UserCropRequest;
+import kr.co.webee.presentation.profile.crop.dto.response.UserCropCreateResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropDetailResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropListResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
-import java.util.Map;
 
 
 @Tag(name = "UserCrop")
@@ -26,7 +26,7 @@ public interface UserCropApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "사용자 재배 작물 등록 성공"),
     })
-    Map<String, Long> createUserCrop(
+    UserCropCreateResponse createUserCrop(
             @Parameter(description = "등록할 사용자 재배 작물 정보", required = true)
             @RequestBody @Valid UserCropRequest request,
 

--- a/src/main/java/kr/co/webee/presentation/profile/crop/controller/UserCropController.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/controller/UserCropController.java
@@ -5,13 +5,13 @@ import kr.co.webee.application.profile.crop.service.UserCropService;
 import kr.co.webee.presentation.annotation.UserId;
 import kr.co.webee.presentation.profile.crop.api.UserCropApi;
 import kr.co.webee.presentation.profile.crop.dto.request.UserCropRequest;
+import kr.co.webee.presentation.profile.crop.dto.response.UserCropCreateResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropDetailResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,7 +21,7 @@ public class UserCropController implements UserCropApi {
 
     @Override
     @PostMapping("")
-    public Map<String, Long> createUserCrop(@RequestBody @Valid UserCropRequest request, @UserId Long userId) {
+    public UserCropCreateResponse createUserCrop(@RequestBody @Valid UserCropRequest request, @UserId Long userId) {
         return userCropService.createUserCrop(request, userId);
     }
 

--- a/src/main/java/kr/co/webee/presentation/profile/crop/controller/UserCropController.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/controller/UserCropController.java
@@ -4,7 +4,8 @@ import jakarta.validation.Valid;
 import kr.co.webee.application.profile.crop.service.UserCropService;
 import kr.co.webee.presentation.annotation.UserId;
 import kr.co.webee.presentation.profile.crop.api.UserCropApi;
-import kr.co.webee.presentation.profile.crop.dto.request.UserCropRequest;
+import kr.co.webee.presentation.profile.crop.dto.request.UserCropCreateRequest;
+import kr.co.webee.presentation.profile.crop.dto.request.UserCropUpdateRequest;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropCreateResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropDetailResponse;
 import kr.co.webee.presentation.profile.crop.dto.response.UserCropListResponse;
@@ -21,7 +22,7 @@ public class UserCropController implements UserCropApi {
 
     @Override
     @PostMapping("")
-    public UserCropCreateResponse createUserCrop(@RequestBody @Valid UserCropRequest request, @UserId Long userId) {
+    public UserCropCreateResponse createUserCrop(@RequestBody @Valid UserCropCreateRequest request, @UserId Long userId) {
         return userCropService.createUserCrop(request, userId);
     }
 
@@ -39,7 +40,7 @@ public class UserCropController implements UserCropApi {
 
     @PutMapping("/{userCropId}")
     @Override
-    public void updateUserCrop(@PathVariable Long userCropId, @RequestBody @Valid UserCropRequest request, @UserId Long userId) {
+    public void updateUserCrop(@PathVariable Long userCropId, @RequestBody @Valid UserCropUpdateRequest request, @UserId Long userId) {
         userCropService.updateUserCrop(userCropId, request, userId);
     }
 

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropCreateRequest.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropCreateRequest.java
@@ -1,0 +1,57 @@
+package kr.co.webee.presentation.profile.crop.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.co.webee.domain.profile.crop.entity.Coordinates;
+import kr.co.webee.domain.profile.crop.entity.Location;
+import kr.co.webee.domain.profile.crop.entity.UserCrop;
+import kr.co.webee.domain.profile.crop.type.CultivationType;
+import kr.co.webee.domain.user.entity.User;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+@Schema(description = "등록할 사용자 재배 작물 정보 request")
+public record UserCropCreateRequest(
+        @Schema(description = "작물명", example = "딸기")
+        @NotBlank
+        String name,
+
+        @Schema(description = "품종", example = "설향")
+        String variety,
+
+        @Schema(description = "재배 방식", example = "CONTROLLED", examples = {"CONTROLLED", "OPEN_FIELD"})
+        @NotNull
+        CultivationType cultivationType,
+
+        @Schema(description = "재배 지역", example = "충청남도 논산시 연무읍 봉동리")
+        @NotBlank
+        String cultivationAddress,
+
+        @Schema(description = "재배 면적", example = "1320")
+        @NotNull
+        Integer cultivationArea,
+
+        @Schema(description = "정식(또는 파종)일", example = "2024-02-25")
+        @NotNull
+        LocalDate plantingDate
+) {
+    public UserCrop toEntity(Coordinates coordinates, User user) {
+        Location cultivationLocation = Location.builder()
+                .address(cultivationAddress)
+                .coordinates(coordinates)
+                .build();
+
+        return UserCrop.builder()
+                .name(name)
+                .variety(variety)
+                .cultivationType(cultivationType)
+                .cultivationLocation(cultivationLocation)
+                .cultivationArea(cultivationArea)
+                .plantingDate(plantingDate)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropUpdateRequest.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropUpdateRequest.java
@@ -13,13 +13,13 @@ import lombok.Builder;
 import java.time.LocalDate;
 
 @Builder
-@Schema(description = "사용자 재배 작물 정보 request")
-public record UserCropRequest(
+@Schema(description = "수정할 사용자 재배 작물 정보 request")
+public record UserCropUpdateRequest(
         @Schema(description = "작물명", example = "딸기")
         @NotBlank
         String name,
 
-        @Schema(description = "품종", example = "설향")
+        @Schema(description = "품종", example = "파인베리")
         String variety,
 
         @Schema(description = "재배 방식", example = "CONTROLLED", examples = {"CONTROLLED", "OPEN_FIELD"})
@@ -30,7 +30,7 @@ public record UserCropRequest(
         @NotBlank
         String cultivationAddress,
 
-        @Schema(description = "재배 면적", example = "1320")
+        @Schema(description = "재배 면적", example = "1500")
         @NotNull
         Integer cultivationArea,
 

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/response/UserCropCreateResponse.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/response/UserCropCreateResponse.java
@@ -1,0 +1,17 @@
+package kr.co.webee.presentation.profile.crop.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "사용자 재배 작물 정보 ID 값")
+public record UserCropCreateResponse(
+        @Schema(description = "사용자 재배 작물 정보 ID", example = "1")
+        Long userCropId
+) {
+    public static UserCropCreateResponse of(Long userCropId) {
+        return UserCropCreateResponse.builder()
+                .userCropId(userCropId)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- `사용자 재배 작물 정보` 등록 API의 반환 값을 기존 Map 객체에서 DTO로 수정합니다.
- `사용자 재배 작물 정보` 등록과 수정 요청 DTO를 분리합니다. 

## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
