### PR TITLE
feat: 사용자 질의응답 API 추가

### DIFF
--- a/src/main/java/kr/co/webee/application/ai/AssistantService.java
+++ b/src/main/java/kr/co/webee/application/ai/AssistantService.java
@@ -1,0 +1,60 @@
+package kr.co.webee.application.ai;
+
+import kr.co.webee.infrastructure.config.ai.AssistantAiExecutor;
+import kr.co.webee.presentation.ai.chat.dto.AssistantResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AssistantService {
+
+    private final AssistantAiExecutor aiExecutor;
+
+    @Value("${app.ai.rag-prompt}")
+    private String ragPrompt;
+
+    @Value("${app.ai.vector-store.topK}")
+    private int topK;
+
+    @Value("${app.ai.vector-store.similarity-threshold}")
+    private double similarityThreshold;
+
+    public AssistantResponse answerUserInput(String input, String conversationId, GenerationMode mode) {
+        if (StringUtils.isBlank(conversationId)) {
+            conversationId = UUID.randomUUID().toString();
+        }
+
+        String result = switch (mode) {
+            case SIMPLE -> aiExecutor.generateSimple(input, conversationId);
+            case RAG -> aiExecutor.generateWithRag(input, conversationId, ragPrompt, getDefaultRagOptions());
+        };
+
+        return new AssistantResponse(result, conversationId);
+    }
+
+    public List<String> getBeeFaqQuestions() {
+        return aiExecutor.getDocuments(
+                "bee faq",
+                new RagSearchOptions(
+                        "type == 'faq' AND category == 'bee'",
+                        topK,
+                        similarityThreshold
+                )
+        );
+    }
+
+    private RagSearchOptions getDefaultRagOptions() {
+        return new RagSearchOptions("type != 'faq'", topK, similarityThreshold);
+    }
+
+    public enum GenerationMode {
+        SIMPLE,
+        RAG
+    }
+}

--- a/src/main/java/kr/co/webee/application/ai/RagSearchOptions.java
+++ b/src/main/java/kr/co/webee/application/ai/RagSearchOptions.java
@@ -1,0 +1,14 @@
+package kr.co.webee.application.ai;
+
+public record RagSearchOptions(
+        String filterExpression,
+        Integer topK,
+        Double similarityThreshold
+) {
+    public RagSearchOptions {
+        if (topK == null || topK <= 0) {
+            throw new IllegalArgumentException("topK must be greater than 0! : " + topK);
+        }
+        if (similarityThreshold == null) similarityThreshold = 0.8;
+    }
+}

--- a/src/main/java/kr/co/webee/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/co/webee/infrastructure/config/SecurityConfig.java
@@ -31,7 +31,8 @@ import static org.springframework.web.bind.annotation.RequestMethod.*;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private static final String[] PUBLIC_ENDPOINTS = {
-            "/api/v1/auth/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**"
+            "/api/v1/auth/**", "/api/v1/assistants/**",
+            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**",
     };
 
     private static final String[] READ_ONLY_ENDPOINTS = {

--- a/src/main/java/kr/co/webee/infrastructure/config/ai/AssistantAiExecutor.java
+++ b/src/main/java/kr/co/webee/infrastructure/config/ai/AssistantAiExecutor.java
@@ -1,0 +1,79 @@
+package kr.co.webee.infrastructure.config.ai;
+
+import kr.co.webee.application.ai.RagSearchOptions;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
+import org.springframework.ai.chat.client.advisor.api.Advisor;
+import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AssistantAiExecutor {
+
+    private final ChatClient chatClient;
+    private final VectorStore vectorStore;
+    private final MessageChatMemoryAdvisor memoryAdvisor;
+    private final SimpleLoggerAdvisor loggerAdvisor;
+
+    public List<String> getDocuments(String query, RagSearchOptions options) {
+        SearchRequest searchRequest = toSearchRequest(query, options);
+
+        List<Document> docs = vectorStore.similaritySearch(searchRequest);
+        if (docs == null || docs.isEmpty()) return List.of();
+        return docs.stream().map(Document::getText).toList();
+    }
+
+    public String generateSimple(String userInput, String conversationId) {
+        return buildPrompt(userInput, conversationId, List.of(loggerAdvisor, memoryAdvisor))
+                .call()
+                .content();
+    }
+
+    public String generateWithRag(String userInput, String conversationId, String prompt, RagSearchOptions options) {
+        return buildPrompt(userInput, conversationId, List.of(
+                loggerAdvisor,
+                memoryAdvisor,
+                buildQaAdvisor(userInput, prompt, options)
+        )).call().content();
+    }
+
+    private Advisor buildQaAdvisor(String userInput, String prompt, RagSearchOptions options) {
+        return QuestionAnswerAdvisor.builder(vectorStore)
+                .searchRequest(toSearchRequest(userInput, options))
+                .promptTemplate(PromptTemplate.builder()
+                        .template(prompt)
+                        .variables(Map.of("userInput", userInput))
+                        .build())
+                .build();
+    }
+
+    private SearchRequest toSearchRequest(String query, RagSearchOptions options) {
+        return SearchRequest.builder()
+                .query(query)
+                .topK(Optional.ofNullable(options.topK()).orElse(10))
+                .similarityThreshold(Optional.ofNullable(options.similarityThreshold()).orElse(0.75))
+                .filterExpression(options.filterExpression())
+                .build();
+    }
+
+    private ChatClient.ChatClientRequestSpec buildPrompt(String userInput, String conversationId, List<Advisor> advisors) {
+        return chatClient.prompt()
+                .system(s -> s.param("language", "Korean").param("character", "챗봇"))
+                .advisors(a -> a.param(ChatMemory.CONVERSATION_ID, conversationId).advisors(advisors))
+                .user(userInput);
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/ai/chat/api/AssistantApi.java
+++ b/src/main/java/kr/co/webee/presentation/ai/chat/api/AssistantApi.java
@@ -1,0 +1,22 @@
+package kr.co.webee.presentation.ai.chat.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.webee.presentation.ai.chat.dto.AssistantRequest;
+import kr.co.webee.presentation.ai.chat.dto.AssistantResponse;
+
+import java.util.List;
+
+@Tag(name = "챗봇 API", description = "질문 응답 API")
+public interface AssistantApi {
+    @Operation(
+            summary = "AI 기반 질문 응답 생성",
+            description = "사용자의 질문에 대해 AI가 실시간으로 응답을 생성합니다. 응답 시간은 평균 1~3초 이내입니다."
+    )
+    @ApiResponse(responseCode = "200", description = "성공")
+    AssistantResponse answerUserInput(AssistantRequest request);
+
+    @Operation(summary = "FAQ 예시 질문 목록 조회", description = "벡터 DB에 저장된 벌 관련 FAQ 예시 질문들을 조회합니다.")
+    List<String> getBeeFaqQuestions();
+}

--- a/src/main/java/kr/co/webee/presentation/ai/chat/controller/AssistantController.java
+++ b/src/main/java/kr/co/webee/presentation/ai/chat/controller/AssistantController.java
@@ -1,0 +1,33 @@
+package kr.co.webee.presentation.ai.chat.controller;
+
+import jakarta.validation.Valid;
+import kr.co.webee.application.ai.AssistantService;
+import kr.co.webee.presentation.ai.chat.api.AssistantApi;
+import kr.co.webee.presentation.ai.chat.dto.AssistantRequest;
+import kr.co.webee.presentation.ai.chat.dto.AssistantResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/assistants")
+@RequiredArgsConstructor
+public class AssistantController implements AssistantApi {
+
+    private final AssistantService assistantService;
+
+    @PostMapping("/messages")
+    public AssistantResponse answerUserInput(@RequestBody @Valid AssistantRequest request) {
+        return assistantService.answerUserInput(
+                request.input(),
+                request.conversationId(),
+                request.mode()
+        );
+    }
+
+    @GetMapping("/sample-questions")
+    public List<String> getBeeFaqQuestions() {
+        return assistantService.getBeeFaqQuestions();
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/ai/chat/dto/AssistantRequest.java
+++ b/src/main/java/kr/co/webee/presentation/ai/chat/dto/AssistantRequest.java
@@ -1,0 +1,18 @@
+package kr.co.webee.presentation.ai.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.application.ai.AssistantService;
+
+@Schema(description = "사용자 입력 요청 객체")
+public record AssistantRequest(
+
+        @Schema(description = "사용자의 입력 내용 (질문, 요청, 명령 등)", example = "호박벌은 어디에 쓰이죠?")
+        String input,
+
+        @Schema(description = "대화 ID (null 가능). null이면 새 대화를 시작합니다.", nullable = true, example = "8a12f9c1-54a3-4d8f-b2c2-017fa38a7763")
+        String conversationId,
+
+        @Schema(description = "SIMPLE 모드, RAG 모드 중 선택", example = "RAG", defaultValue = "RAG")
+        AssistantService.GenerationMode mode
+) {
+}

--- a/src/main/java/kr/co/webee/presentation/ai/chat/dto/AssistantResponse.java
+++ b/src/main/java/kr/co/webee/presentation/ai/chat/dto/AssistantResponse.java
@@ -1,0 +1,14 @@
+package kr.co.webee.presentation.ai.chat.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "AI 응답 결과 객체")
+public record AssistantResponse(
+
+        @Schema(description = "AI가 생성한 응답 텍스트", example = "호박벌은 토마토, 파프리카, 딸기 등 온실작물의 자가수분에 효과적입니다.")
+        String answer,
+
+        @Schema(description = "대화 식별자 (세션 ID)", example = "8a12f9c1-54a3-4d8f-b2c2-017fa38a7763")
+        String conversationId
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+    open-in-view: false
 
   data:
     redis:
@@ -27,7 +25,7 @@ spring:
         options:
           model: gpt-4o
           temperature: 0.7
-          maxCompletionTokens: 10000
+          maxCompletionTokens: 1024
 
     vector-store:
       redis:
@@ -72,11 +70,13 @@ app:
 
     rag-prompt: >
       Question: {userInput}
-      
-        ---------------------
-        {question_answer_context}
-        ---------------------
-      
-      - Answer briefly and politely, like a helpful chat assistant.
-      - Use the context only if it directly answers the question.
-      - If nothing is relevant, respond: "요청하신 정보를 찾을 수 없습니다."
+    
+      ---------------------
+      {question_answer_context}
+      ---------------------
+    
+      - If the context clearly answers the question, provide a short and clear response in Korean.
+      - If the context contains general information only, start your answer with "일반적으로는" and explain it’s not specific to the user's question.
+      - If the context is unrelated, respond in Korean: "요청하신 정보를 찾을 수 없습니다."
+      - Do not guess, assume, or use any external knowledge not in the context.
+      - Keep the language simple and trustworthy, suitable for farmers with little AI experience.


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #32 
- close #33 

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 사용자 질의응답 API를 추가합니다.
  - 초기 예제 질문 API
  - 질의 응답 API
- RAG 내에서 못 찾을 경우, 일반적인 내용을 제공하도록 프롬프트를 수정합니다.
- 최대 토큰 개수를 10000 -> 1024로 줄입니다.
- 로그인 하지 않아도 챗봇을 사용할 수 있도록 허용합니다.

## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- RAG로만 하니 RAG에 데이터가 없어서 그런지 계속 "요청하신 정보를 찾을 수 없습니다." 라고 하네요..! 데이터를 추가하거나 프롬프트를 바꾸던가 해야 할 것 같아요