### PR TITLE
feat: 사업자등록정보 등록, 조회 API 추가

### DIFF
--- a/src/main/java/kr/co/webee/application/profile/businesscert/service/BusinessCertificateService.java
+++ b/src/main/java/kr/co/webee/application/profile/businesscert/service/BusinessCertificateService.java
@@ -9,6 +9,7 @@ import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.infrastructure.geocoding.client.GeocodingClient;
 import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateDetailResponse;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -50,4 +51,11 @@ public class BusinessCertificateService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public BusinessCertificateDetailResponse getBusinessCertificateDetail(Long businessCertificateId) {
+        BusinessCertificate businessCertificate = businessCertificateRepository.findById(businessCertificateId)
+                .orElseThrow(() -> new EntityNotFoundException("Business Certificate not found"));
+
+        return BusinessCertificateDetailResponse.from(businessCertificate);
+    }
 }

--- a/src/main/java/kr/co/webee/application/profile/businesscert/service/BusinessCertificateService.java
+++ b/src/main/java/kr/co/webee/application/profile/businesscert/service/BusinessCertificateService.java
@@ -1,0 +1,38 @@
+package kr.co.webee.application.profile.businesscert.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import kr.co.webee.domain.profile.businesscert.entity.BusinessCertificate;
+import kr.co.webee.domain.profile.businesscert.repository.BusinessCertificateRepository;
+import kr.co.webee.domain.profile.crop.entity.Coordinates;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
+import kr.co.webee.infrastructure.geocoding.client.GeocodingClient;
+import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class BusinessCertificateService {
+    private final BusinessCertificateRepository businessCertificateRepository;
+    private final UserRepository userRepository;
+    private final GeocodingClient geocodingClient;
+
+    public BusinessCertificateCreateResponse createBusinessCertificate(BusinessCertificateCreateRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        //open api 사업자등록증 인증 기능 추후 구현
+
+        //사업자등록증 이미지 첨부(선택) 기능 추후 구현
+
+        Coordinates coordinates = geocodingClient.getCoordinateFrom(request.businessAddress());
+
+        BusinessCertificate businessCertificate = request.toEntity(coordinates, user);
+        businessCertificateRepository.save(businessCertificate);
+
+        return BusinessCertificateCreateResponse.of(businessCertificate.getId());
+    }
+}

--- a/src/main/java/kr/co/webee/application/profile/businesscert/service/BusinessCertificateService.java
+++ b/src/main/java/kr/co/webee/application/profile/businesscert/service/BusinessCertificateService.java
@@ -9,8 +9,12 @@ import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.infrastructure.geocoding.client.GeocodingClient;
 import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 
 @Service
@@ -20,6 +24,7 @@ public class BusinessCertificateService {
     private final UserRepository userRepository;
     private final GeocodingClient geocodingClient;
 
+    @Transactional
     public BusinessCertificateCreateResponse createBusinessCertificate(BusinessCertificateCreateRequest request, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
@@ -35,4 +40,14 @@ public class BusinessCertificateService {
 
         return BusinessCertificateCreateResponse.of(businessCertificate.getId());
     }
+
+    @Transactional(readOnly = true)
+    public List<BusinessCertificateListResponse> getBusinessCertificateList() {
+        List<BusinessCertificate> businessCertificates = businessCertificateRepository.findAll();
+
+        return businessCertificates.stream()
+                .map(BusinessCertificateListResponse::from)
+                .toList();
+    }
+
 }

--- a/src/main/java/kr/co/webee/domain/profile/businesscert/entity/BusinessCertificate.java
+++ b/src/main/java/kr/co/webee/domain/profile/businesscert/entity/BusinessCertificate.java
@@ -2,6 +2,7 @@ package kr.co.webee.domain.profile.businesscert.entity;
 
 import jakarta.persistence.*;
 import kr.co.webee.domain.common.BaseTimeEntity;
+import kr.co.webee.domain.profile.crop.entity.Coordinates;
 import kr.co.webee.domain.profile.crop.entity.Location;
 import kr.co.webee.domain.user.entity.User;
 import lombok.AccessLevel;
@@ -41,7 +42,7 @@ public class BusinessCertificate extends BaseTimeEntity {
 
     private String onlineStoreUrl;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
@@ -66,5 +67,13 @@ public class BusinessCertificate extends BaseTimeEntity {
         this.imageUrl=imageUrl;
         this.onlineStoreUrl = onlineStoreUrl;
         this.user=Objects.requireNonNull(user, "user는 null이 될 수 없습니다.");
+    }
+
+    public String getBusinessAddress() {
+        return businessLocation.getAddress();
+    }
+
+    public Coordinates getAddressCoordinates() {
+        return businessLocation.getCoordinates();
     }
 }

--- a/src/main/java/kr/co/webee/domain/profile/businesscert/entity/BusinessCertificate.java
+++ b/src/main/java/kr/co/webee/domain/profile/businesscert/entity/BusinessCertificate.java
@@ -2,6 +2,7 @@ package kr.co.webee.domain.profile.businesscert.entity;
 
 import jakarta.persistence.*;
 import kr.co.webee.domain.common.BaseTimeEntity;
+import kr.co.webee.domain.profile.crop.entity.Location;
 import kr.co.webee.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -34,25 +35,19 @@ public class BusinessCertificate extends BaseTimeEntity {
     private String companyName;
 
     @Column(nullable = false)
-    private String address;
-
-    @Column(nullable = false)
-    private Double latitude;
-
-    @Column(nullable = false)
-    private Double longitude;
+    private Location businessLocation;
 
     private String imageUrl;
 
-    private String smartStoreUrl;
+    private String onlineStoreUrl;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
-    public BusinessCertificate(String registrationNumber, String representativeName, LocalDate commencementDate,
-                               String companyName, String address, Double latitude, Double longitude, String imageUrl, User user, String smartStoreUrl) {
+    public BusinessCertificate(String registrationNumber, String representativeName, LocalDate commencementDate, String companyName,
+                               Location businessLocation, String imageUrl, User user, String onlineStoreUrl) {
         if (!StringUtils.hasText(registrationNumber)) {
             throw new IllegalArgumentException("registrationNumber는 null이거나 빈 문자열이 될 수 없습니다.");
         }
@@ -62,19 +57,14 @@ public class BusinessCertificate extends BaseTimeEntity {
         if (!StringUtils.hasText(companyName)) {
             throw new IllegalArgumentException("companyName은 null이거나 빈 문자열이 될 수 없습니다.");
         }
-        if (!StringUtils.hasText(address)) {
-            throw new IllegalArgumentException("address는 null이거나 빈 문자열이 될 수 없습니다.");
-        }
 
         this.registrationNumber=registrationNumber;
         this.representativeName=representativeName;
         this.commencementDate= Objects.requireNonNull(commencementDate, "commencementDate는 null이 될 수 없습니다.");
         this.companyName=companyName;
-        this.address=address;
-        this.latitude=Objects.requireNonNull(latitude, "latitude는 null이 될 수 없습니다.");
-        this.longitude=Objects.requireNonNull(longitude, "longitude는 null이 될 수 없습니다.");
+        this.businessLocation= Objects.requireNonNull(businessLocation, "businessLocation은 null이 될 수 없습니다.");
         this.imageUrl=imageUrl;
-        this.smartStoreUrl=smartStoreUrl;
+        this.onlineStoreUrl = onlineStoreUrl;
         this.user=Objects.requireNonNull(user, "user는 null이 될 수 없습니다.");
     }
 }

--- a/src/main/java/kr/co/webee/domain/profile/businesscert/repository/BusinessCertificateRepository.java
+++ b/src/main/java/kr/co/webee/domain/profile/businesscert/repository/BusinessCertificateRepository.java
@@ -1,0 +1,9 @@
+package kr.co.webee.domain.profile.businesscert.repository;
+
+import kr.co.webee.domain.profile.businesscert.entity.BusinessCertificate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BusinessCertificateRepository extends JpaRepository<BusinessCertificate, Long> {
+}

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/api/BusinessCertificateApi.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/api/BusinessCertificateApi.java
@@ -1,0 +1,30 @@
+package kr.co.webee.presentation.profile.businesscert.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.webee.presentation.annotation.UserId;
+import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "사업자등록정보 API", description = "사업자등록정보 관련 API")
+public interface BusinessCertificateApi {
+    @Operation(
+            summary = "사업자등록정보 등록",
+            description = "사업자등록정보를 등록합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사업자등록정보 등록 성공"),
+    })
+    BusinessCertificateCreateResponse createBusinessCertificate(
+            @Parameter(description = "사업자등록정보", required = true)
+            @RequestBody @Valid BusinessCertificateCreateRequest request,
+
+            @Parameter(hidden = true)
+            @UserId Long userId
+    );
+}

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/api/BusinessCertificateApi.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/api/BusinessCertificateApi.java
@@ -9,7 +9,9 @@ import jakarta.validation.Valid;
 import kr.co.webee.presentation.annotation.UserId;
 import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateDetailResponse;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateListResponse;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
@@ -39,4 +41,14 @@ public interface BusinessCertificateApi {
             @ApiResponse(responseCode = "200", description = "사업자등록정보 목록 조회 성공"),
     })
     List<BusinessCertificateListResponse> getBusinessCertificateList();
+
+    @Operation(
+            summary = "사업자등록정보 상세 조회",
+            description = "사업자등록정보 상세 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사업자등록정보 상세 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 사업자등록정보 없음")
+    })
+    BusinessCertificateDetailResponse getBusinessCertificateDetail(@PathVariable Long businessCertificateId);
 }

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/api/BusinessCertificateApi.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/api/BusinessCertificateApi.java
@@ -9,7 +9,10 @@ import jakarta.validation.Valid;
 import kr.co.webee.presentation.annotation.UserId;
 import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateListResponse;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 @Tag(name = "사업자등록정보 API", description = "사업자등록정보 관련 API")
 public interface BusinessCertificateApi {
@@ -27,4 +30,13 @@ public interface BusinessCertificateApi {
             @Parameter(hidden = true)
             @UserId Long userId
     );
+
+    @Operation(
+            summary = "사업자등록정보 목록 조회",
+            description = "사업자등록정보 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사업자등록정보 목록 조회 성공"),
+    })
+    List<BusinessCertificateListResponse> getBusinessCertificateList();
 }

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/controller/BusinessCertificateController.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/controller/BusinessCertificateController.java
@@ -6,8 +6,11 @@ import kr.co.webee.presentation.annotation.UserId;
 import kr.co.webee.presentation.profile.businesscert.api.BusinessCertificateApi;
 import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/profile/business-certificate")
@@ -20,6 +23,12 @@ public class BusinessCertificateController implements BusinessCertificateApi {
     public BusinessCertificateCreateResponse createBusinessCertificate(@RequestBody @Valid BusinessCertificateCreateRequest request,
                                                                        @UserId Long userId) {
         return businessCertificateService.createBusinessCertificate(request, userId);
+    }
+
+    @Override
+    @GetMapping
+    public List<BusinessCertificateListResponse> getBusinessCertificateList() {
+        return businessCertificateService.getBusinessCertificateList();
     }
 
 }

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/controller/BusinessCertificateController.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/controller/BusinessCertificateController.java
@@ -6,6 +6,7 @@ import kr.co.webee.presentation.annotation.UserId;
 import kr.co.webee.presentation.profile.businesscert.api.BusinessCertificateApi;
 import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateDetailResponse;
 import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -31,4 +32,9 @@ public class BusinessCertificateController implements BusinessCertificateApi {
         return businessCertificateService.getBusinessCertificateList();
     }
 
+    @Override
+    @GetMapping("/{businessCertificateId}")
+    public BusinessCertificateDetailResponse getBusinessCertificateDetail(@PathVariable Long businessCertificateId) {
+        return businessCertificateService.getBusinessCertificateDetail(businessCertificateId);
+    }
 }

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/controller/BusinessCertificateController.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/controller/BusinessCertificateController.java
@@ -1,0 +1,25 @@
+package kr.co.webee.presentation.profile.businesscert.controller;
+
+import jakarta.validation.Valid;
+import kr.co.webee.application.profile.businesscert.service.BusinessCertificateService;
+import kr.co.webee.presentation.annotation.UserId;
+import kr.co.webee.presentation.profile.businesscert.api.BusinessCertificateApi;
+import kr.co.webee.presentation.profile.businesscert.dto.request.BusinessCertificateCreateRequest;
+import kr.co.webee.presentation.profile.businesscert.dto.response.BusinessCertificateCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/profile/business-certificate")
+@RequiredArgsConstructor
+public class BusinessCertificateController implements BusinessCertificateApi {
+    private final BusinessCertificateService businessCertificateService;
+
+    @Override
+    @PostMapping()
+    public BusinessCertificateCreateResponse createBusinessCertificate(@RequestBody @Valid BusinessCertificateCreateRequest request,
+                                                                       @UserId Long userId) {
+        return businessCertificateService.createBusinessCertificate(request, userId);
+    }
+
+}

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/request/BusinessCertificateCreateRequest.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/request/BusinessCertificateCreateRequest.java
@@ -9,6 +9,7 @@ import kr.co.webee.domain.user.entity.User;
 
 import java.time.LocalDate;
 
+@Schema(description = "사업자등록정보 등록 정보 request")
 public record BusinessCertificateCreateRequest(
         @Schema(description = "사업자등록번호", example = "1023456798")
         @NotNull

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/request/BusinessCertificateCreateRequest.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/request/BusinessCertificateCreateRequest.java
@@ -1,0 +1,53 @@
+package kr.co.webee.presentation.profile.businesscert.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import kr.co.webee.domain.profile.businesscert.entity.BusinessCertificate;
+import kr.co.webee.domain.profile.crop.entity.Coordinates;
+import kr.co.webee.domain.profile.crop.entity.Location;
+import kr.co.webee.domain.user.entity.User;
+
+import java.time.LocalDate;
+
+public record BusinessCertificateCreateRequest(
+        @Schema(description = "사업자등록번호", example = "1023456798")
+        @NotNull
+        String registrationNumber,
+
+        @Schema(description = "대표자명", example = "홍길동")
+        @NotNull
+        String representativeName,
+
+        @Schema(description = "개업 일자", example = "2020-03-15")
+        @NotNull
+        LocalDate commencementDate,
+
+        @Schema(description = "상호명", example = "꿀벌 농장")
+        @NotNull
+        String companyName,
+
+        @Schema(description = "사업장 소재지", example = "전라북도 전주시 완산구 홍산로")
+        @NotNull
+        String businessAddress,
+
+        @Schema(description = "온라인 스토어 링크", example = "https://smartstore.naver.com/honeybee", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String onlineStoreUrl
+) {
+    public BusinessCertificate toEntity(Coordinates coordinates, User user) {
+        Location businessLocation = Location.builder()
+                .address(businessAddress)
+                .coordinates(coordinates)
+                .build();
+
+        return BusinessCertificate.builder()
+                .registrationNumber(registrationNumber)
+                .representativeName(representativeName)
+                .commencementDate(commencementDate)
+                .companyName(companyName)
+                .businessLocation(businessLocation)
+                //.imageUrl()
+                .onlineStoreUrl(onlineStoreUrl)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/response/BusinessCertificateCreateResponse.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/response/BusinessCertificateCreateResponse.java
@@ -1,0 +1,14 @@
+package kr.co.webee.presentation.profile.businesscert.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BusinessCertificateCreateResponse(
+        Long businessCertificateId
+) {
+    public static BusinessCertificateCreateResponse of(Long businessCertificateId) {
+        return BusinessCertificateCreateResponse.builder()
+                .businessCertificateId(businessCertificateId)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/response/BusinessCertificateCreateResponse.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/response/BusinessCertificateCreateResponse.java
@@ -1,9 +1,12 @@
 package kr.co.webee.presentation.profile.businesscert.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사업자등록정보 등록 response")
 public record BusinessCertificateCreateResponse(
+        @Schema(description = "사업자등록정보 ID", example = "1")
         Long businessCertificateId
 ) {
     public static BusinessCertificateCreateResponse of(Long businessCertificateId) {

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/response/BusinessCertificateDetailResponse.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/response/BusinessCertificateDetailResponse.java
@@ -1,0 +1,53 @@
+package kr.co.webee.presentation.profile.businesscert.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.domain.profile.businesscert.entity.BusinessCertificate;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+@Schema(description = "사업자등록정보 상세 정보 response")
+public record BusinessCertificateDetailResponse(
+        @Schema(description = "사업자등록정보 ID", example = "1")
+        Long businessCertificateId,
+
+        @Schema(description = "상호명", example = "꿀벌 농장")
+        String companyName,
+
+        @Schema(description = "사업장 소재지", example = "전라북도 전주시 완산구 홍산로")
+        String businessAddress,
+
+        @Schema(description = "사업장 소재지 위도", example = "35.8168945124229")
+        Double latitude,
+
+        @Schema(description = "사업장 소재지 경도", example = "127.105944703404")
+        Double longitude,
+
+        @Schema(description = "사업자등록번호", example = "1023456798")
+        String registrationNumber,
+
+        @Schema(description = "대표자명", example = "홍길동")
+        String representativeName,
+
+        @Schema(description = "개업 일자", example = "2020-03-15")
+        LocalDate commencementDate,
+
+        @Schema(description = "온라인 스토어 링크", example = "https://smartstore.naver.com/honeybee")
+        String onlineStoreUrl
+
+        //사업자등록증 이미지(nullable)
+) {
+        public static BusinessCertificateDetailResponse from(BusinessCertificate businessCertificate) {
+                return BusinessCertificateDetailResponse.builder()
+                        .businessCertificateId(businessCertificate.getId())
+                        .companyName(businessCertificate.getCompanyName())
+                        .businessAddress(businessCertificate.getBusinessAddress())
+                        .latitude(businessCertificate.getAddressCoordinates().getLatitude())
+                        .longitude(businessCertificate.getAddressCoordinates().getLongitude())
+                        .registrationNumber(businessCertificate.getRegistrationNumber())
+                        .representativeName(businessCertificate.getRepresentativeName())
+                        .commencementDate(businessCertificate.getCommencementDate())
+                        .build();
+        }
+}

--- a/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/response/BusinessCertificateListResponse.java
+++ b/src/main/java/kr/co/webee/presentation/profile/businesscert/dto/response/BusinessCertificateListResponse.java
@@ -1,0 +1,34 @@
+package kr.co.webee.presentation.profile.businesscert.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.domain.profile.businesscert.entity.BusinessCertificate;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "사업자등록정보 목록 response")
+public record BusinessCertificateListResponse(
+        @Schema(description = "사업자등록정보 ID", example = "1")
+        Long businessCertificateId,
+
+        @Schema(description = "상호명", example = "꿀벌 농장")
+        String companyName,
+
+        @Schema(description = "사업장 소재지", example = "전라북도 전주시 완산구 홍산로")
+        String businessAddress,
+
+        @Schema(description = "사업장 소재지 위도", example = "35.8168945124229")
+        Double latitude,
+
+        @Schema(description = "사업장 소재지 경도", example = "127.105944703404")
+        Double longitude
+) {
+    public static BusinessCertificateListResponse from(BusinessCertificate businessCertificate) {
+        return BusinessCertificateListResponse.builder()
+                .businessCertificateId(businessCertificate.getId())
+                .companyName(businessCertificate.getCompanyName())
+                .businessAddress(businessCertificate.getBusinessAddress())
+                .latitude(businessCertificate.getAddressCoordinates().getLatitude())
+                .longitude(businessCertificate.getAddressCoordinates().getLongitude())
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 사업자등록정보와 관련된 기본 API를 추가합니다.
  - 사업자등록정보 등록 기능(추후 open api로 사업체 진위여부 확인, 사업자등록증 이미지 첨부 기능 구현 필요)
  - 사업자등록정보 전체, 상세 조회 기능(각 사용자마다 조회 기능도 필요)

## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

프론트 요구사항에 맞춰 기본 기능만 우선적으로 구현했습니다!