### PR TITLE
fix: openai 모델을 4o에서 4o-mini로 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
       api-key: ${OPENAI_API_KEY:}
       chat:
         options:
-          model: gpt-4o
+          model: gpt-4o-mini
           temperature: 0.7
           maxCompletionTokens: 1024
 


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->


## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- GPT 모델을 4o에서 4o-mini로 교체합니다.



모델 | 입력 (1M 토큰) | 출력 (1M 토큰) | 비고
-- | -- | -- | --
GPT-4o | $5.00 (Batch: $2.50) | $15.00 (Batch: $7.50) | 멀티모달
GPT-4o mini | $0.15 (Batch: $0.075) | $0.60 (Batch: $0.30) | 초경량 모델

질문 - 호박벌은 어디에 쓰이죠?
GPT-4o - 호박벌은 토마토, 파프리카, 딸기 등 온실작물의 자가수분에 효과적입니다.
GPT-4o-mini - 호박벌은 토마토, 파프리카, 딸기 등 온실작물의 자가수분에 효과적으로 사용됩니다.


## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
