### PR TITLE
fix: 사용자 재배 작물 목록 조회 시 응답값에 정식(파종)일 추가

### DIFF
--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/response/UserCropListResponse.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/response/UserCropListResponse.java
@@ -5,6 +5,8 @@ import kr.co.webee.domain.profile.crop.entity.UserCrop;
 import kr.co.webee.domain.profile.crop.type.CultivationType;
 import lombok.Builder;
 
+import java.time.LocalDate;
+
 @Builder
 @Schema(description = "사용자 재배 작물 정보 목록")
 public record UserCropListResponse(
@@ -24,7 +26,10 @@ public record UserCropListResponse(
         String cultivationAddress,
 
         @Schema(description = "재배 면적", example = "1320")
-        Integer cultivationArea
+        Integer cultivationArea,
+
+        @Schema(description = "파종(정식)일", example = "2025-05-02")
+        LocalDate plantingDate
 ) {
     public static UserCropListResponse from(UserCrop userCrop) {
         return UserCropListResponse.builder()
@@ -34,6 +39,7 @@ public record UserCropListResponse(
                 .cultivationType(userCrop.getCultivationType())
                 .cultivationAddress(userCrop.getCultivationAddress())
                 .cultivationArea(userCrop.getCultivationArea())
+                .plantingDate(userCrop.getPlantingDate())
                 .build();
     }
 }


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
사용자 재배 작물 목록 조회 시 응답값에 정식(파종)일을 추가합니다.

## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
