### PR TITLE
fix: BeeRecommendation 엔티티와 User 엔티티 매핑

### DIFF
--- a/src/main/java/kr/co/webee/application/bee/recommend/service/BeeRecommendationService.java
+++ b/src/main/java/kr/co/webee/application/bee/recommend/service/BeeRecommendationService.java
@@ -6,6 +6,8 @@ import kr.co.webee.domain.bee.recommend.entity.BeeRecommendation;
 import kr.co.webee.domain.bee.recommend.repository.BeeRecommendationRepository;
 import kr.co.webee.domain.profile.crop.entity.UserCrop;
 import kr.co.webee.domain.profile.crop.repository.UserCropRepository;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.infrastructure.ai.AiPromptExecutor;
 import kr.co.webee.infrastructure.ai.PromptTemplateRegistry;
 import kr.co.webee.presentation.bee.recommend.dto.request.BeeRecommendationRequest;
@@ -24,8 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BeeRecommendationService {
     private final BeeRecommendationRepository beeRecommendationRepository;
-    private final UserCropRepository userCropRepository;
-
+    private final UserRepository userRepository;
     private final AiPromptExecutor aiPromptExecutor;
     private final PromptTemplateRegistry promptRegistry;
 
@@ -49,11 +50,10 @@ public class BeeRecommendationService {
     }
 
     @Transactional
-    public BeeRecommendationCreateResponse createBeeRecommendation(BeeRecommendationRequest request) {
-        UserCrop userCrop = userCropRepository.findById(request.userCropId())
-                .orElseThrow(() -> new EntityNotFoundException("User Crop not found"));
-
-        BeeRecommendation beeRecommendation = request.toEntity(userCrop);
+    public BeeRecommendationCreateResponse createBeeRecommendation(BeeRecommendationRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        BeeRecommendation beeRecommendation = request.toEntity(user);
         beeRecommendationRepository.save(beeRecommendation);
         return BeeRecommendationCreateResponse.of(beeRecommendation.getId());
     }

--- a/src/main/java/kr/co/webee/domain/bee/recommend/entity/BeeRecommendation.java
+++ b/src/main/java/kr/co/webee/domain/bee/recommend/entity/BeeRecommendation.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import kr.co.webee.domain.bee.type.BeeType;
 import kr.co.webee.domain.common.BaseTimeEntity;
 import kr.co.webee.domain.profile.crop.entity.UserCrop;
+import kr.co.webee.domain.profile.crop.type.CultivationType;
+import kr.co.webee.domain.user.entity.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,16 @@ public class BeeRecommendation extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String cropName;
+
+    @Column(nullable = false)
+    private String cultivationAddress;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CultivationType cultivationType;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -41,12 +53,19 @@ public class BeeRecommendation extends BaseTimeEntity {
     private String usageTip;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_crop_id", nullable = false)
-    private UserCrop userCrop;
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Builder
-    public BeeRecommendation(BeeType beeType, String characteristics, LocalDate inputStartDate,
-                             LocalDate inputEndDate, String caution, String usageTip, UserCrop userCrop) {
+    public BeeRecommendation(String cropName, String cultivationAddress, CultivationType cultivationType,
+                             BeeType beeType, String characteristics, LocalDate inputStartDate,
+                             LocalDate inputEndDate, String caution, String usageTip, User user) {
+        if (!StringUtils.hasText(cropName)) {
+            throw new IllegalArgumentException("cropName은 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+        if (!StringUtils.hasText(cultivationAddress)) {
+            throw new IllegalArgumentException("cultivationAddress은 null이거나 빈 문자열이 될 수 없습니다.");
+        }
         if (!StringUtils.hasText(characteristics)) {
             throw new IllegalArgumentException("characteristics은 null이거나 빈 문자열이 될 수 없습니다.");
         }
@@ -57,12 +76,15 @@ public class BeeRecommendation extends BaseTimeEntity {
             throw new IllegalArgumentException("usageTip은 null이거나 빈 문자열이 될 수 없습니다.");
         }
 
+        this.cropName=cropName;
+        this.cultivationAddress=cultivationAddress;
+        this.cultivationType = Objects.requireNonNull(cultivationType, "cultivationType은 null이 될 수 없습니다.");
         this.beeType = Objects.requireNonNull(beeType, "beeType은 null이 될 수 없습니다.");
         this.characteristics = characteristics;
         this.inputStartDate=Objects.requireNonNull(inputStartDate, "inputStartDate는 null이 될 수 없습니다.");
         this.inputEndDate=Objects.requireNonNull(inputEndDate, "inputEndDate는 null이 될 수 없습니다.");
         this.caution=caution;
         this.usageTip=usageTip;
-        this.userCrop = Objects.requireNonNull(userCrop, "userCrop은 null이 될 수 없습니다.");
+        this.user = Objects.requireNonNull(user, "user는 null이 될 수 없습니다.");
     }
 }

--- a/src/main/java/kr/co/webee/domain/bee/recommend/repository/BeeRecommendationRepository.java
+++ b/src/main/java/kr/co/webee/domain/bee/recommend/repository/BeeRecommendationRepository.java
@@ -10,10 +10,5 @@ import java.util.List;
 
 @Repository
 public interface BeeRecommendationRepository extends JpaRepository<BeeRecommendation, Long> {
-    @Query("""
-            SELECT br FROM BeeRecommendation br
-            JOIN FETCH br.userCrop uc
-            WHERE uc.user.id = :userId
-            """)
     List<BeeRecommendation> findByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/kr/co/webee/presentation/bee/recommend/api/BeeRecommendationApi.java
+++ b/src/main/java/kr/co/webee/presentation/bee/recommend/api/BeeRecommendationApi.java
@@ -30,7 +30,7 @@ public interface BeeRecommendationApi {
     )
     @ApiResponse(responseCode = "200", description = "성공")
     @ApiResponse(responseCode = "404", description = "사용자 재배 작물 없음")
-    BeeRecommendationCreateResponse createBeeRecommendation(@RequestBody BeeRecommendationRequest request);
+    BeeRecommendationCreateResponse createBeeRecommendation(@RequestBody BeeRecommendationRequest request, @UserId Long userId);
 
     @Operation(
             summary = "수정벌 추천 내역 목록 조회",

--- a/src/main/java/kr/co/webee/presentation/bee/recommend/controller/BeeRecommendationController.java
+++ b/src/main/java/kr/co/webee/presentation/bee/recommend/controller/BeeRecommendationController.java
@@ -28,8 +28,8 @@ public class BeeRecommendationController implements BeeRecommendationApi {
 
     @Override
     @PostMapping("")
-    public BeeRecommendationCreateResponse createBeeRecommendation(@RequestBody BeeRecommendationRequest request) {
-        return beeRecommendationService.createBeeRecommendation(request);
+    public BeeRecommendationCreateResponse createBeeRecommendation(@RequestBody BeeRecommendationRequest request, @UserId Long userId) {
+        return beeRecommendationService.createBeeRecommendation(request, userId);
     }
 
     @Override

--- a/src/main/java/kr/co/webee/presentation/bee/recommend/dto/request/BeeRecommendationRequest.java
+++ b/src/main/java/kr/co/webee/presentation/bee/recommend/dto/request/BeeRecommendationRequest.java
@@ -2,15 +2,32 @@ package kr.co.webee.presentation.bee.recommend.dto.request;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import kr.co.webee.domain.bee.recommend.entity.BeeRecommendation;
 import kr.co.webee.domain.bee.type.BeeType;
 import kr.co.webee.domain.profile.crop.entity.UserCrop;
+import kr.co.webee.domain.profile.crop.type.CultivationType;
+import kr.co.webee.domain.user.entity.User;
 
 import java.time.LocalDate;
 
 @Schema(description = "수정벌 추천 내역 저장 request")
 public record BeeRecommendationRequest(
+        @Schema(description = "작물명", example = "딸기")
+        @NotBlank
+        String cropName,
+
+        @Schema(description = "재배 지역", example = "충청남도 논산시 연무읍 봉동리")
+        @NotBlank
+        String cultivationAddress,
+
+        @Schema(description = "재배 방식", example = "CONTROLLED", examples = {"CONTROLLED", "OPEN_FIELD"})
+        @NotNull
+        CultivationType cultivationType,
+
         @Schema(description = "수정벌 종류", example = "EUROPEAN_BUMBLEBEE")
+        @NotBlank
         BeeType beeType,
 
         @Schema(
@@ -20,12 +37,15 @@ public record BeeRecommendationRequest(
                         "효율적인 꽃가루 전달 능력"
 
         )
+        @NotBlank
         String characteristics,
 
         @Schema(description = "수정벌 투입 적정 시작일", example = "2025-03-10")
+        @NotBlank
         LocalDate inputStartDate,
 
         @Schema(description = "수정벌 투입 적정 마감일", example = "2025-04-08")
+        @NotBlank
         LocalDate inputEndDate,
 
         @Schema(
@@ -33,6 +53,7 @@ public record BeeRecommendationRequest(
                 example = "서양뒤영벌은 높은 온도와 습도에 민감한 점\n" +
                         "과도한 농약 사용은 서양뒤영벌의 활동에 부정적 영향"
         )
+        @NotBlank
         String caution,
 
         @Schema(
@@ -41,20 +62,21 @@ public record BeeRecommendationRequest(
                         "벌통을 햇빛이 직접 닿지 않는 곳에 배치하여 벌의 스트레스를 줄여주세요.\n" +
                         "수분이 잘 이루어지도록 하루에 한 번씩 시설 내 온도와 습도를 체크하세요."
         )
-        String usageTip,
-
-        @Schema(description = "사용자 재배 작물 ID", example = "1")
-        Long userCropId
+        @NotBlank
+        String usageTip
 ) {
-    public BeeRecommendation toEntity(UserCrop userCrop) {
+    public BeeRecommendation toEntity(User user) {
         return BeeRecommendation.builder()
+                .cropName(cropName)
+                .cultivationAddress(cultivationAddress)
+                .cultivationType(cultivationType)
                 .beeType(beeType)
                 .characteristics(characteristics)
                 .inputStartDate(inputStartDate)
                 .inputEndDate(inputEndDate)
                 .caution(caution)
                 .usageTip(usageTip)
-                .userCrop(userCrop)
+                .user(user)
                 .build();
     }
 }

--- a/src/main/java/kr/co/webee/presentation/bee/recommend/dto/response/BeeRecommendationListResponse.java
+++ b/src/main/java/kr/co/webee/presentation/bee/recommend/dto/response/BeeRecommendationListResponse.java
@@ -43,9 +43,9 @@ public record BeeRecommendationListResponse(
                 .beeType(beeRecommendation.getBeeType())
                 .inputStartDate(beeRecommendation.getInputStartDate())
                 .inputEndDate(beeRecommendation.getInputEndDate())
-                .cropName(beeRecommendation.getUserCrop().getName())
-                .cultivationAddress(beeRecommendation.getUserCrop().getCultivationAddress())
-                .cultivationType(beeRecommendation.getUserCrop().getCultivationType())
+                .cropName(beeRecommendation.getCropName())
+                .cultivationAddress(beeRecommendation.getCultivationAddress())
+                .cultivationType(beeRecommendation.getCultivationType())
                 .createdAt(LocalDate.from(beeRecommendation.getCreatedAt()))
                 .build();
     }


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 기존의 BeeRecommendation 엔티티와 UserCrop 엔티티 매핑을 끊고, User 엔티티를 매핑합니다. 
  - 새로운 작물 정보에 대한 수정벌 추천 내역을 저장하기 위함입니다.

## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
