### PR TITLE
feat: 업체 정보 등록 시 사업자등록정보 진위 확인한 뒤 등록

### DIFF
--- a/src/main/java/kr/co/webee/common/error/ErrorType.java
+++ b/src/main/java/kr/co/webee/common/error/ErrorType.java
@@ -46,7 +46,11 @@ public enum ErrorType {
     FILE_UPLOAD_FAILED(BAD_GATEWAY, ERROR, "FILE_001", "파일 업로드에 실패했습니다"),
 
     // BeeErrorType
-    BEE_DISEASE_DETECT_FAILED(BAD_GATEWAY, ERROR, "BEE_001", "꿀벌 질병 탐지에 실패했습니다.");
+    BEE_DISEASE_DETECT_FAILED(BAD_GATEWAY, ERROR, "BEE_001", "꿀벌 질병 탐지에 실패했습니다."),
+
+    //BusinessErrorType
+    BUSINESS_CERTIFICATE_AUTHENTICATION_FAILED(BAD_GATEWAY, ERROR,"BUSINESS_CERTIFICATE_001","사업자등록정보 진위확인에 실패했습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final Level logLevel;

--- a/src/main/java/kr/co/webee/infrastructure/businesscert/client/BusinessCertificateValidationClient.java
+++ b/src/main/java/kr/co/webee/infrastructure/businesscert/client/BusinessCertificateValidationClient.java
@@ -1,0 +1,54 @@
+package kr.co.webee.infrastructure.businesscert.client;
+
+import kr.co.webee.infrastructure.businesscert.dto.BusinessCertificateInfoRequest;
+import kr.co.webee.infrastructure.businesscert.dto.BusinessCertificateValidationRequest;
+import kr.co.webee.infrastructure.businesscert.dto.BusinessCertificateValidationResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class BusinessCertificateValidationClient {
+    private final String PUBLIC_BUSINESS_CERTIFICATE_VALIDATION_API_URL = "https://api.odcloud.kr/api/nts-businessman/v1/validate";
+    private final String AUTHORIZATION_REQUEST_PARAMETER_KEY = "serviceKey";
+
+    @Value("${business-certificate-validation.api-key}")
+    private String apiKey;
+
+    private final RestClient restClient;
+
+    public BusinessCertificateValidationClient(RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder
+                .baseUrl(PUBLIC_BUSINESS_CERTIFICATE_VALIDATION_API_URL)
+                .build();
+    }
+
+    public boolean validateBusinessCertificate(BusinessCertificateInfoRequest businessCertificateInfo) {
+        List<BusinessCertificateInfoRequest> requests = new ArrayList<>();
+        requests.add(businessCertificateInfo);
+        BusinessCertificateValidationRequest validationRequest = BusinessCertificateValidationRequest.of(requests);
+
+        BusinessCertificateValidationResponse response = restClient.post()
+                .uri(uriBuilder -> uriBuilder.queryParam(AUTHORIZATION_REQUEST_PARAMETER_KEY,
+                        URLDecoder.decode(apiKey, StandardCharsets.UTF_8)).build())
+                .body(validationRequest)
+                .retrieve()
+                .body(BusinessCertificateValidationResponse.class);
+
+        if (response == null || response.data().isEmpty()) {
+            throw new IllegalArgumentException("사업자등록인증 API 호출에 실패했습니다.");
+        }
+
+        String validCode = response.data().get(0).valid();
+        return "01".equals(validCode);
+    }
+}

--- a/src/main/java/kr/co/webee/infrastructure/businesscert/dto/BusinessCertificateInfoRequest.java
+++ b/src/main/java/kr/co/webee/infrastructure/businesscert/dto/BusinessCertificateInfoRequest.java
@@ -1,0 +1,32 @@
+package kr.co.webee.infrastructure.businesscert.dto;
+
+import kr.co.webee.presentation.profile.business.dto.request.BusinessCreateRequest;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+
+@Builder
+public record BusinessCertificateInfoRequest(
+        String b_no,
+        String start_dt,
+        String p_nm
+) {
+    public static BusinessCertificateInfoRequest from(BusinessCreateRequest request) {
+        LocalDate commencementDate = request.commencementDate();
+
+        String formattedDate = String.format("%04d%02d%02d",
+                commencementDate.getYear(),
+                commencementDate.getMonthValue(),
+                commencementDate.getDayOfMonth());
+
+        return BusinessCertificateInfoRequest.builder()
+                .b_no(request.registrationNumber())
+                .start_dt(formattedDate)
+                .p_nm(request.representativeName())
+                .build();
+    }
+}
+
+
+

--- a/src/main/java/kr/co/webee/infrastructure/businesscert/dto/BusinessCertificateValidationRequest.java
+++ b/src/main/java/kr/co/webee/infrastructure/businesscert/dto/BusinessCertificateValidationRequest.java
@@ -1,0 +1,16 @@
+package kr.co.webee.infrastructure.businesscert.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record BusinessCertificateValidationRequest(
+        List<BusinessCertificateInfoRequest> businesses
+) {
+    public static BusinessCertificateValidationRequest of(List<BusinessCertificateInfoRequest> requests) {
+        return BusinessCertificateValidationRequest.builder()
+                .businesses(requests)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/infrastructure/businesscert/dto/BusinessCertificateValidationResponse.java
+++ b/src/main/java/kr/co/webee/infrastructure/businesscert/dto/BusinessCertificateValidationResponse.java
@@ -1,0 +1,13 @@
+package kr.co.webee.infrastructure.businesscert.dto;
+
+import java.util.List;
+
+public record BusinessCertificateValidationResponse(
+    List<ValidationInfo> data
+) {
+    public record ValidationInfo(
+        String valid
+    ){
+    }
+}
+

--- a/src/main/java/kr/co/webee/presentation/profile/business/api/BusinessApi.java
+++ b/src/main/java/kr/co/webee/presentation/profile/business/api/BusinessApi.java
@@ -28,7 +28,10 @@ public interface BusinessApi {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "업체 등록 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식")
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식"),
+            @ApiResponse(responseCode = "502", description = "사업자등록정보 진위 확인 실패")
+
+
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     BusinessCreateResponse createBusiness(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,3 +85,6 @@ bee:
   recommendation:
     nongsaro:
       request-parameter-list: classpath:nongsaro-crop-pollination-request-parameter-list.csv
+
+business-certificate-validation:
+  api-key: ${BUSINESS_CERTIFICATE_API_KEY:}


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->


## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 업체 정보 등록 시 사업자등록정보 진위 확인한 뒤 등록하도록 합니다.
  - 공공데이터 국세청_사업자등록정보 진위확인 및 상태조회 서비스 API 사용

## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
