### PR TITLE
feat: OAuth 소셜 로그인 추가

### DIFF
--- a/src/main/java/kr/co/webee/application/auth/dto/OAuthSignInDto.java
+++ b/src/main/java/kr/co/webee/application/auth/dto/OAuthSignInDto.java
@@ -1,0 +1,18 @@
+package kr.co.webee.application.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record OAuthSignInDto(
+        boolean isNewUser,
+        String name,
+        JwtTokenDto jwtTokenDto
+) {
+    public static OAuthSignInDto of(boolean isNewUser, String name, JwtTokenDto jwtTokenDto){
+        return OAuthSignInDto.builder()
+                .isNewUser(isNewUser)
+                .name(name)
+                .jwtTokenDto(jwtTokenDto)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/application/auth/service/OAuthClientFactory.java
+++ b/src/main/java/kr/co/webee/application/auth/service/OAuthClientFactory.java
@@ -1,0 +1,27 @@
+package kr.co.webee.application.auth.service;
+
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.oauth.enums.OAuthPlatform;
+import kr.co.webee.infrastructure.oauth.client.KakaoClient;
+import kr.co.webee.infrastructure.oauth.client.NaverClient;
+import kr.co.webee.infrastructure.oauth.client.OAuthClient;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@RequiredArgsConstructor
+public class OAuthClientFactory {
+    private final NaverClient naverClient;
+    private final KakaoClient kakaoClient;
+
+    public OAuthClient getOAuthClient(OAuthPlatform platform) {
+        return switch (platform) {
+            case NAVER -> naverClient;
+            case KAKAO -> kakaoClient;
+            default -> throw new BusinessException(ErrorType.UNSUPPORTED_SOCIAL_PLATFORM);
+        };
+    }
+}

--- a/src/main/java/kr/co/webee/application/auth/service/OAuthService.java
+++ b/src/main/java/kr/co/webee/application/auth/service/OAuthService.java
@@ -1,0 +1,83 @@
+package kr.co.webee.application.auth.service;
+
+import kr.co.webee.application.auth.dto.JwtTokenDto;
+import kr.co.webee.application.auth.dto.OAuthSignInDto;
+import kr.co.webee.application.auth.helper.JwtHelper;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.oauth.entity.OAuth;
+import kr.co.webee.domain.oauth.enums.OAuthPlatform;
+import kr.co.webee.domain.oauth.repository.OAuthRepository;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
+import kr.co.webee.infrastructure.oauth.client.OAuthClient;
+import kr.co.webee.infrastructure.oauth.dto.OAuthUserInfoDto;
+import kr.co.webee.presentation.auth.dto.request.UserInfoRegisterRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@RequiredArgsConstructor
+@Service
+public class OAuthService {
+    private final UserRepository userRepository;
+    private final OAuthRepository oAuthRepository;
+    private final JwtHelper jwtHelper;
+    private final OAuthClientFactory oAuthClientFactory;
+
+    @Transactional
+    public OAuthSignInDto signIn(OAuthPlatform platform, String code) {
+        OAuthClient oAuthClient = oAuthClientFactory.getOAuthClient(platform);
+
+        String accessToken = oAuthClient.getAccessToken(code);
+        OAuthUserInfoDto userInfo = oAuthClient.getUserInfo(accessToken);
+
+        return issueToken(platform, userInfo);
+    }
+
+    private OAuthSignInDto issueToken(OAuthPlatform platform, OAuthUserInfoDto userInfo) {
+        String username = platform + "_" + userInfo.platformId();
+
+        return userRepository.findByUsername(username)
+                .map(user -> {
+                    return buildSignInResponse(user, false);
+                })
+                .orElseGet(() -> {
+                    User registeredUser = registerUser(platform, userInfo);
+                    return buildSignInResponse(registeredUser, true);
+                });
+    }
+
+    @Transactional
+    public void registerUserInfo(UserInfoRegisterRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorType.ENTITY_NOT_FOUND));
+
+        user.updateName(request.name());
+    }
+
+    private OAuthSignInDto buildSignInResponse(User user, boolean isNewUser) {
+        JwtTokenDto token = jwtHelper.createToken(user.getId(), user.getUsername());
+        return OAuthSignInDto.of(isNewUser, user.getName(), token);
+    }
+
+    private User registerUser(OAuthPlatform platform, OAuthUserInfoDto userInfo) {
+        String username = platform + "_" + userInfo.platformId();
+
+        User user = User.builder()
+                .username(username)
+                .name(username)
+                .build();
+
+        OAuth oAuth = OAuth.builder()
+                .platform(platform)
+                .platformId(userInfo.platformId())
+                .user(user)
+                .build();
+
+        oAuthRepository.save(oAuth);
+
+        return user;
+    }
+}

--- a/src/main/java/kr/co/webee/common/error/ErrorType.java
+++ b/src/main/java/kr/co/webee/common/error/ErrorType.java
@@ -25,7 +25,6 @@ public enum ErrorType {
     MALFORMED_ACCESS_TOKEN(UNAUTHORIZED, DEBUG, "AUTH_004", "잘못된 형식의 토큰입니다"),
     TAMPERED_ACCESS_TOKEN(UNAUTHORIZED, DEBUG, "AUTH_005", "변조된 토큰입니다"),
     UNSUPPORTED_JWT_TOKEN(UNAUTHORIZED, DEBUG, "AUTH_006", "지원하지 않는 JWT 토큰입니다"),
-    UNSUPPORTED_SOCIAL_TYPE(UNAUTHORIZED, DEBUG, "AUTH_007", "지원하지 않는 소셜 타입입니다"),
     UNKNOWN_TOKEN_ERROR(UNAUTHORIZED, DEBUG, "AUTH_008", "알 수 없는 JWT 토큰 에러입니다."),
     INVALID_CREDENTIALS(UNAUTHORIZED, DEBUG, "AUTH_009", "해당 사용자의 정보가 없거나 일치하지 않아 처리할 수 없습니다"),
     INVALID_REFRESH_TOKEN(UNAUTHORIZED, DEBUG, "AUTH_010", "유효하지 않은 리프레시 토큰입니다"),
@@ -33,8 +32,9 @@ public enum ErrorType {
     ALREADY_EXIST_PHONE_NUMBER(CONFLICT, DEBUG, "AUTH_011", "이미 존재하는 전화번호 입니다"),
 
     // OauthErrorType
-    SOCIAL_MEMBER_NOT_FOUND(NOT_FOUND, DEBUG, "OAUTH_001", "찾을 수 없는 소셜 회원입니다"),
-    EMAIL_NOT_FOUND_IN_ID_TOKEN(BAD_REQUEST, DEBUG, "OAUTH_002", "ID 토큰 필드에 이메일이 없습니다"),
+    UNSUPPORTED_SOCIAL_PLATFORM(BAD_REQUEST, DEBUG, "OAUTH_001", "지원하지 않는 소셜 로그인 플랫폼입니다."),
+    OAUTH_TOKEN_REQUEST_FAILED(UNAUTHORIZED, DEBUG, "OAUTH_002", "소셜 서버로부터 액세스 토큰을 가져오는데 실패했습니다."),
+    OAUTH_USER_INFO_REQUEST_FAILED(UNAUTHORIZED, DEBUG, "OAUTH_003", "소셜 사용자 정보를 가져오는데 실패했습니다."),
 
     // DatabaseErrorType
     ENTITY_NOT_FOUND(NOT_FOUND, DEBUG, "DB_001", "해당 엔티티를 찾을 수 없습니다"),

--- a/src/main/java/kr/co/webee/domain/oauth/entity/OAuth.java
+++ b/src/main/java/kr/co/webee/domain/oauth/entity/OAuth.java
@@ -1,0 +1,40 @@
+package kr.co.webee.domain.oauth.entity;
+
+import jakarta.persistence.*;
+import kr.co.webee.domain.oauth.enums.OAuthPlatform;
+import kr.co.webee.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class OAuth {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private OAuthPlatform platform;
+
+    private String platformId;
+
+    @OneToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    private OAuth(OAuthPlatform platform, String platformId, User user) {
+        if (!StringUtils.hasText(platformId)) {
+            throw new IllegalArgumentException("platformId는 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+        this.platform = Objects.requireNonNull(platform, "platform은 null이 될 수 없습니다.");
+        this.platformId = platformId;
+        this.user = Objects.requireNonNull(user, "user은 null이 될 수 없습니다.");
+    }
+}

--- a/src/main/java/kr/co/webee/domain/oauth/enums/OAuthPlatform.java
+++ b/src/main/java/kr/co/webee/domain/oauth/enums/OAuthPlatform.java
@@ -1,0 +1,13 @@
+package kr.co.webee.domain.oauth.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuthPlatform {
+    KAKAO("카카오"),
+    NAVER("네이버");
+
+    private final String description;
+}

--- a/src/main/java/kr/co/webee/domain/oauth/repository/OAuthRepository.java
+++ b/src/main/java/kr/co/webee/domain/oauth/repository/OAuthRepository.java
@@ -1,0 +1,9 @@
+package kr.co.webee.domain.oauth.repository;
+
+import kr.co.webee.domain.oauth.entity.OAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OAuthRepository extends JpaRepository<OAuth, Long> {
+}

--- a/src/main/java/kr/co/webee/domain/user/entity/User.java
+++ b/src/main/java/kr/co/webee/domain/user/entity/User.java
@@ -23,7 +23,6 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String username;
 
-    @Column(nullable = false)
     private String password;
 
     @Column(nullable = false)
@@ -39,9 +38,6 @@ public class User extends BaseTimeEntity {
         if (!StringUtils.hasText(username)) {
             throw new IllegalArgumentException("username은 null이거나 빈 문자열이 될 수 없습니다.");
         }
-        if (!StringUtils.hasText(password)) {
-            throw new IllegalArgumentException("password는 null이거나 빈 문자열이 될 수 없습니다.");
-        }
         if (!StringUtils.hasText(name)) {
             throw new IllegalArgumentException("name은 null이거나 빈 문자열이 될 수 없습니다.");
         }
@@ -51,6 +47,13 @@ public class User extends BaseTimeEntity {
         this.name = name;
         this.phoneNumber=phoneNumber;
         this.businessRegistered=businessRegistered;
+    }
+
+    public void updateName(String name) {
+        if (!StringUtils.hasText(name)) {
+            throw new IllegalArgumentException("name은 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+        this.name = name;
     }
 
     public boolean isSameId(Long userId) {

--- a/src/main/java/kr/co/webee/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/co/webee/infrastructure/config/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
@@ -34,7 +35,8 @@ public class SecurityConfig {
             "/api/v1/bee/diagnosis",
             "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**",
             "/api/v1/reports/harvest-prediction",
-            "/api/v1/auth/preorder/phone"
+            "/api/v1/auth/preorder/phone",
+            "/api/v1/oauth/sign-in/**",
     };
 
     private static final String[] READ_ONLY_ENDPOINTS = {
@@ -42,7 +44,7 @@ public class SecurityConfig {
     };
 
     @Value("${was.cors-allow-origins}")
-    private List<String> corsOrigins;
+    private String corsAllowOrigins;
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtExceptionFilter jwtExceptionFilter;
@@ -79,7 +81,11 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(corsOrigins);
+        List<String> origins = Arrays.stream(corsAllowOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        configuration.setAllowedOrigins(origins);
         configuration.setAllowedMethods(List.of(GET.name(), POST.name(), PUT.name(), PATCH.name(), DELETE.name(), OPTIONS.name()));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setMaxAge(3600L); // Cache preflight

--- a/src/main/java/kr/co/webee/infrastructure/oauth/client/KakaoClient.java
+++ b/src/main/java/kr/co/webee/infrastructure/oauth/client/KakaoClient.java
@@ -1,0 +1,67 @@
+package kr.co.webee.infrastructure.oauth.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.infrastructure.oauth.dto.OAuthUserInfoDto;
+import kr.co.webee.infrastructure.oauth.properties.OAuthProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class KakaoClient implements OAuthClient {
+    private final RestClient restClient;
+    private final OAuthProperties.Platform properties;
+
+    public KakaoClient(OAuthProperties properties) {
+        this.restClient = RestClient.create();
+        this.properties = properties.getKakao();
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", properties.getClientId());
+        body.add("redirect_uri", properties.getRedirectUri());
+        body.add("code", code);
+        body.add("client_secret", properties.getClientSecret());
+
+        try {
+            JsonNode root = restClient.post()
+                    .uri(properties.getTokenUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            return root.get("access_token").asText();
+        } catch (Exception e) {
+            log.error("카카오 소셜 서버로부터 액세스 토큰을 가져오는데 실패했습니다. {}", e.getMessage());
+            throw new BusinessException(ErrorType.OAUTH_TOKEN_REQUEST_FAILED);
+        }
+    }
+
+    @Override
+    public OAuthUserInfoDto getUserInfo(String accessToken) {
+        try {
+            JsonNode root = restClient.post()
+                    .uri(properties.getUserInfoUri())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .headers(headers -> headers.setBearerAuth(accessToken))
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            String platformId = root.get("id").asText();
+            return OAuthUserInfoDto.of(platformId);
+        } catch (Exception e) {
+            log.error("카카오 소셜 사용자 정보를 가져오는데 실패했습니다. {}", e.getMessage());
+            throw new BusinessException(ErrorType.OAUTH_USER_INFO_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/kr/co/webee/infrastructure/oauth/client/NaverClient.java
+++ b/src/main/java/kr/co/webee/infrastructure/oauth/client/NaverClient.java
@@ -1,0 +1,62 @@
+package kr.co.webee.infrastructure.oauth.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.infrastructure.oauth.dto.OAuthUserInfoDto;
+import kr.co.webee.infrastructure.oauth.properties.OAuthProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class NaverClient implements OAuthClient{
+    private final RestClient restClient;
+    private final OAuthProperties.Platform properties;
+
+    public NaverClient(OAuthProperties properties) {
+        this.restClient = RestClient.create();
+        this.properties = properties.getNaver();
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        String url = UriComponentsBuilder.fromUriString(properties.getTokenUri())
+                .queryParam("grant_type", "authorization_code")
+                .queryParam("client_id", properties.getClientId())
+                .queryParam("client_secret", properties.getClientSecret())
+                .queryParam("code", code)
+                .toUriString();
+
+        try {
+            JsonNode root = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            return root.get("access_token").asText();
+        } catch (Exception e) {
+            log.error("네이버 소셜 서버로부터 액세스 토큰을 가져오는데 실패했습니다. {}", e.getMessage());
+            throw new BusinessException(ErrorType.OAUTH_TOKEN_REQUEST_FAILED);
+        }
+    }
+
+    @Override
+    public OAuthUserInfoDto getUserInfo(String accessToken) {
+        try {
+            JsonNode root = restClient.get()
+                    .uri(properties.getUserInfoUri())
+                    .headers(headers -> headers.setBearerAuth(accessToken))
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            String platformId = root.path("response").get("id").asText();
+            return OAuthUserInfoDto.of(platformId);
+        } catch (Exception e) {
+            log.error("네이버 소셜 사용자 정보를 가져오는데 실패했습니다. {}", e.getMessage());
+            throw new BusinessException(ErrorType.OAUTH_USER_INFO_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/kr/co/webee/infrastructure/oauth/client/OAuthClient.java
+++ b/src/main/java/kr/co/webee/infrastructure/oauth/client/OAuthClient.java
@@ -1,0 +1,10 @@
+package kr.co.webee.infrastructure.oauth.client;
+
+import kr.co.webee.infrastructure.oauth.dto.OAuthUserInfoDto;
+
+public interface OAuthClient {
+
+    String getAccessToken(String code);
+
+    OAuthUserInfoDto getUserInfo(String accessToken);
+}

--- a/src/main/java/kr/co/webee/infrastructure/oauth/dto/OAuthUserInfoDto.java
+++ b/src/main/java/kr/co/webee/infrastructure/oauth/dto/OAuthUserInfoDto.java
@@ -1,0 +1,14 @@
+package kr.co.webee.infrastructure.oauth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record OAuthUserInfoDto(
+        String platformId
+){
+    public static OAuthUserInfoDto of(String platformId) {
+        return OAuthUserInfoDto.builder()
+                .platformId(platformId)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/infrastructure/oauth/properties/OAuthProperties.java
+++ b/src/main/java/kr/co/webee/infrastructure/oauth/properties/OAuthProperties.java
@@ -1,0 +1,26 @@
+package kr.co.webee.infrastructure.oauth.properties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "oauth2")
+public class OAuthProperties {
+    private Platform naver;
+    private Platform kakao;
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Platform {
+        private final String clientId;
+        private final String clientSecret;
+        private final String redirectUri;
+        private final String tokenUri;
+        private final String userInfoUri;
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/auth/api/OAuthApi.java
+++ b/src/main/java/kr/co/webee/presentation/auth/api/OAuthApi.java
@@ -1,0 +1,83 @@
+package kr.co.webee.presentation.auth.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import kr.co.webee.common.auth.security.CustomUserDetails;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.domain.oauth.enums.OAuthPlatform;
+import kr.co.webee.presentation.auth.dto.request.UserInfoRegisterRequest;
+import kr.co.webee.presentation.auth.dto.response.OAuthSignInResponse;
+import kr.co.webee.presentation.support.annotation.ApiDocsErrorType;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "OAuth", description = "소셜 로그인(OAuth) 관련 API")
+public interface OAuthApi {
+
+    @Operation(
+            summary = "소셜 로그인",
+            description = "카카오/네이버 인가 코드로 로그인합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "로그인 성공",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = OAuthSignInResponse.class)
+            )
+    )
+    @ApiDocsErrorType(value = {
+            ErrorType.UNSUPPORTED_SOCIAL_PLATFORM,
+            ErrorType.OAUTH_TOKEN_REQUEST_FAILED,
+            ErrorType.OAUTH_USER_INFO_REQUEST_FAILED
+    })
+    OAuthSignInResponse signIn(
+            @Parameter(
+                    description = "소셜 플랫폼",
+                    required = true,
+                    schema = @Schema(implementation = OAuthPlatform.class)
+            )
+            @PathVariable OAuthPlatform platform,
+
+            @Parameter(
+                    description = "소셜 로그인 인가 코드",
+                    required = true,
+                    schema = @Schema(type = "string"),
+                    example = "authorization_code_issued_by_provider"
+            )
+            @RequestParam String code,
+
+            HttpServletResponse response
+    );
+
+    @Operation(
+            summary = "소셜 로그인 사용자 정보 등록",
+            description = "OAuth로 최초 가입한 사용자의 표시 이름 등 추가 정보를 등록합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "등록 성공",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(description = "성공 응답 본문", type = "string", example = "OK")
+            )
+    )
+    @ApiDocsErrorType(value = {
+            ErrorType.FAILED_AUTHENTICATION,
+            ErrorType.ENTITY_NOT_FOUND,
+            ErrorType.FAILED_VALIDATION
+    })
+    String registerUserInfo(
+            @RequestBody @Valid UserInfoRegisterRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+}

--- a/src/main/java/kr/co/webee/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/webee/presentation/auth/controller/OAuthController.java
@@ -1,0 +1,58 @@
+package kr.co.webee.presentation.auth.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import kr.co.webee.application.auth.dto.JwtTokenDto;
+import kr.co.webee.application.auth.dto.OAuthSignInDto;
+import kr.co.webee.application.auth.service.OAuthService;
+import kr.co.webee.common.auth.security.CustomUserDetails;
+import kr.co.webee.common.constant.JwtConstants;
+import kr.co.webee.domain.oauth.enums.OAuthPlatform;
+import kr.co.webee.presentation.auth.api.OAuthApi;
+import kr.co.webee.presentation.auth.dto.request.UserInfoRegisterRequest;
+import kr.co.webee.presentation.auth.dto.response.OAuthSignInResponse;
+import kr.co.webee.presentation.support.util.cookie.CookieUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/oauth")
+public class OAuthController implements OAuthApi {
+    private final OAuthService oAuthService;
+
+    @Override
+    @GetMapping("/sign-in/{platform}")
+    public OAuthSignInResponse signIn(
+            @PathVariable OAuthPlatform platform,
+            @RequestParam String code,
+            HttpServletResponse response
+    ) {
+        OAuthSignInDto signInDto = oAuthService.signIn(platform, code);
+        createTokenResponse(signInDto.jwtTokenDto(), response);
+        return OAuthSignInResponse.of(signInDto.isNewUser(), signInDto.name());
+    }
+
+    @Override
+    @PostMapping("/register")
+    public String registerUserInfo(
+            @RequestBody @Valid UserInfoRegisterRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        oAuthService.registerUserInfo(request, userDetails.getUserId());
+        return "OK";
+    }
+
+    private void createTokenResponse(JwtTokenDto jwtTokenDto, HttpServletResponse response) {
+        ResponseCookie cookie = CookieUtil.createCookie(JwtConstants.REFRESH_TOKEN_COOKIE_KEY, jwtTokenDto.refreshToken(), Duration.ofDays(7).toSeconds());
+
+        response.addHeader(HttpHeaders.AUTHORIZATION, JwtConstants.ACCESS_TOKEN_HEADER_PREFIX + jwtTokenDto.accessToken());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/auth/dto/request/UserInfoRegisterRequest.java
+++ b/src/main/java/kr/co/webee/presentation/auth/dto/request/UserInfoRegisterRequest.java
@@ -1,0 +1,14 @@
+package kr.co.webee.presentation.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "사용자 정보 등록 request")
+public record UserInfoRegisterRequest(
+        @Schema(description = "이름", example = "exampleName")
+        @NotBlank
+        String name
+) {
+}

--- a/src/main/java/kr/co/webee/presentation/auth/dto/response/OAuthSignInResponse.java
+++ b/src/main/java/kr/co/webee/presentation/auth/dto/response/OAuthSignInResponse.java
@@ -1,0 +1,21 @@
+package kr.co.webee.presentation.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "소셜 로그인 response")
+public record OAuthSignInResponse(
+        @Schema(description = "신규 사용자 여부", example = "true")
+        boolean isNewUser,
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        String name
+) {
+    public static OAuthSignInResponse of(boolean isNewUser, String name) {
+        return OAuthSignInResponse.builder()
+                .isNewUser(isNewUser)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,3 +90,17 @@ bee:
 
 business-certificate-validation:
   api-key: ${BUSINESS_CERTIFICATE_API_KEY:}
+
+oauth2:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID:}
+    client-secret: ${KAKAO_CLIENT_SECRET:}
+    redirect-uri: ${KAKAO_REDIRECT_URL:}
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+  naver:
+    client-id: ${NAVER_CLIENT_ID:}
+    client-secret: ${NAVER_CLIENT_SECRET:}
+    redirect-uri: ${NAVER_REDIRECT_URL:}
+    token-uri: https://nid.naver.com/oauth2.0/token
+    user-info-uri: https://openapi.naver.com/v1/nid/me


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #102

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 네이버, 카카오 소셜 로그인 기능을 추가합니다.

## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 카카오·네이버 소셜 로그인 추가 및 OAuth 기반 자동 회원 등록
  * OAuth 로그인 시 JWT를 응답 헤더와 리프레시 토큰 쿠키로 전달
  * OAuth 가입 이후 이름 등록용 엔드포인트 추가
  * OAuth 공급자 설정(token/user-info/redirect 등)을 환경변수로 구성 가능

* **Bug Fixes / Behavior Changes**
  * OAuth 관련 오류 응답 타입 및 메시지 정비로 가독성 개선
  * 사용자 이름 업데이트 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->