### PR TITLE
fix: OAuth 콜백 시 프론트로 바로 redirect 하도록 수정

### DIFF
--- a/src/main/java/kr/co/webee/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/kr/co/webee/infrastructure/config/SecurityConfig.java
@@ -36,11 +36,12 @@ public class SecurityConfig {
             "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**",
             "/api/v1/reports/harvest-prediction",
             "/api/v1/auth/preorder/phone",
-            "/api/v1/oauth/sign-in/**",
+            "/api/v1/oauth/sign-in/**"
     };
 
     private static final String[] READ_ONLY_ENDPOINTS = {
-            "/api/v1/products/**", "/api/v1/users/**", "/api/v1/profile/business/**"
+            "/api/v1/products/**", "/api/v1/users/**", "/api/v1/profile/business/**",
+            "/api/v1/oauth/callback/**"
     };
 
     @Value("${was.cors-allow-origins}")

--- a/src/main/java/kr/co/webee/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/kr/co/webee/presentation/auth/controller/OAuthController.java
@@ -14,18 +14,38 @@ import kr.co.webee.presentation.auth.dto.response.OAuthSignInResponse;
 import kr.co.webee.presentation.support.util.cookie.CookieUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/oauth")
 public class OAuthController implements OAuthApi {
     private final OAuthService oAuthService;
+    private static final String MOBILE_OAUTH_BASE = "webee://oauth";
+
+    @GetMapping("/callback/{platform}")
+    public ResponseEntity<Void> redirectToMobileApp(
+            @PathVariable OAuthPlatform platform,
+            @RequestParam(required = false) String code
+    ) {
+        URI location = UriComponentsBuilder
+                .fromUriString(MOBILE_OAUTH_BASE)
+                .queryParam("code", code)
+                .queryParam("platform", platform.name())
+                .encode(StandardCharsets.UTF_8)
+                .build().toUri();
+
+        return ResponseEntity.status(HttpStatus.FOUND).location(location).build();
+    }
 
     @Override
     @GetMapping("/sign-in/{platform}")

--- a/src/main/java/kr/co/webee/presentation/support/handler/ApiResponseHandler.java
+++ b/src/main/java/kr/co/webee/presentation/support/handler/ApiResponseHandler.java
@@ -36,6 +36,9 @@ public class ApiResponseHandler implements ResponseBodyAdvice<Object> {
 
         HttpStatus resolve = HttpStatus.resolve(servletResponse.getStatus());
         if (resolve == null || !resolve.is2xxSuccessful()) {
+            if (resolve != null && resolve.is3xxRedirection()) {
+                return body;
+            }
             if (body instanceof ApiErrorDto error) {
                 return ApiResponse.fail(error);
             }


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 리액트 네이티브 앱에서 oauth 사용 시 별도 브릿지 엔드포인트 필요
- 소셜 인가 서버 콜백 시 프론트(앱)에 바로 redirect 하도록 수정


## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모바일 앱으로의 OAuth 콜백 엔드포인트 추가 — 플랫폼별 딥 링크(webee://oauth)를 통해 인증 코드 전달 지원

* **개선사항**
  * HTTP 리다이렉트(3xx) 응답 처리 개선으로 리디렉션 동작이 안정적으로 동작하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->