### PR TITLE
fix: 작물 저장 시 정식일, 수확시기(시작일, 마감일) 받도록 수정

### DIFF
--- a/src/main/java/kr/co/webee/application/profile/crop/service/UserCropService.java
+++ b/src/main/java/kr/co/webee/application/profile/crop/service/UserCropService.java
@@ -20,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -84,7 +83,15 @@ public class UserCropService {
             userCrop.updateCultivationLocation(cultivationLocation);
         }
 
-        userCrop.update(request.name(), request.variety(), request.cultivationType(), request.cultivationArea(), request.plantingDate());
+        userCrop.update(
+                request.name(),
+                request.variety(),
+                request.cultivationType(),
+                request.cultivationArea(),
+                request.plantingDate(),
+                request.harvestStartDate(),
+                request.harvestEndDate()
+        );
     }
 
     @Transactional

--- a/src/main/java/kr/co/webee/domain/profile/crop/entity/UserCrop.java
+++ b/src/main/java/kr/co/webee/domain/profile/crop/entity/UserCrop.java
@@ -40,13 +40,20 @@ public class UserCrop extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDate plantingDate;
 
+    @Column
+    private LocalDate harvestStartDate;
+
+    @Column
+    private LocalDate harvestEndDate;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder
     public UserCrop(String name, String variety, CultivationType cultivationType,
-                    Location cultivationLocation, Integer cultivationArea, LocalDate plantingDate, User user) {
+                    Location cultivationLocation, Integer cultivationArea, LocalDate plantingDate,
+                    LocalDate harvestStartDate, LocalDate harvestEndDate, User user) {
         if (!StringUtils.hasText(name)) {
             throw new IllegalArgumentException("name은 null이거나 빈 문자열이 될 수 없습니다.");
         }
@@ -57,11 +64,17 @@ public class UserCrop extends BaseTimeEntity {
         this.cultivationLocation =Objects.requireNonNull(cultivationLocation,"cultivationLocation은 null이 될 수 없습니다.");
         this.cultivationArea = Objects.requireNonNull(cultivationArea, "cultivationArea는 null이 될 수 없습니다.");
         this.plantingDate = Objects.requireNonNull(plantingDate, "plantingDate는 null이 될 수 없습니다.");
+        this.harvestStartDate = Objects.requireNonNull(harvestStartDate, "harvestStartDate는 null이 될 수 없습니다.");
+        this.harvestEndDate  = Objects.requireNonNull(harvestEndDate, "harvestEndDate는 null이 될 수 없습니다.");
+        if (harvestStartDate.isAfter(harvestEndDate)) {
+            throw new IllegalArgumentException("harvestStartDate는 harvestEndDate보다 늦을 수 없습니다.");
+        }
         this.user = Objects.requireNonNull(user, "user는 null이 될 수 없습니다.");
     }
 
     public void update(String name, String variety, CultivationType cultivationType,
-                       Integer cultivationArea, LocalDate plantingDate) {
+                       Integer cultivationArea, LocalDate plantingDate,
+                       LocalDate harvestStartDate, LocalDate harvestEndDate) {
         if (!StringUtils.hasText(name)) {
             throw new IllegalArgumentException("name은 null이거나 빈 문자열이 될 수 없습니다.");
         }
@@ -71,6 +84,11 @@ public class UserCrop extends BaseTimeEntity {
         this.cultivationType = Objects.requireNonNull(cultivationType, "cultivationType은 null이 될 수 없습니다.");
         this.cultivationArea = Objects.requireNonNull(cultivationArea, "cultivationArea는 null이 될 수 없습니다.");
         this.plantingDate = Objects.requireNonNull(plantingDate, "plantingDate는 null이 될 수 없습니다.");
+        this.harvestStartDate = Objects.requireNonNull(harvestStartDate, "harvestStartDate는 null이 될 수 없습니다.");
+        this.harvestEndDate  = Objects.requireNonNull(harvestEndDate, "harvestEndDate는 null이 될 수 없습니다.");
+        if (harvestStartDate.isAfter(harvestEndDate)) {
+            throw new IllegalArgumentException("harvestStartDate는 harvestEndDate보다 늦을 수 없습니다.");
+        }
     }
 
     public void updateCultivationLocation(Location cultivationLocation) {

--- a/src/main/java/kr/co/webee/presentation/bee/recommendation/dto/request/UserCropInfoRequest.java
+++ b/src/main/java/kr/co/webee/presentation/bee/recommendation/dto/request/UserCropInfoRequest.java
@@ -29,12 +29,12 @@ public record UserCropInfoRequest(
         @NotNull
         Integer cultivationArea,
 
-        @Schema(description = "정식(또는 파종)일", example = "2024-02-25")
+        @Schema(description = "정식일", example = "2024-02-25")
         @NotNull
         LocalDate plantingDate
 ) {
     public String describe() {
-        return String.format("작물명: %s, 품종: %s, 재배 방식: %s, 재배 지역: %s, 재배 면적: %s, 정식(또는 파종)일: %s",
+        return String.format("작물명: %s, 품종: %s, 재배 방식: %s, 재배 지역: %s, 재배 면적: %s, 정식일: %s",
                 this.name, this.variety, this.cultivationType.getDescription(), this.cultivationAddress, this.cultivationArea, this.plantingDate.toString());
     }
 }

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropCreateRequest.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropCreateRequest.java
@@ -34,9 +34,17 @@ public record UserCropCreateRequest(
         @NotNull
         Integer cultivationArea,
 
-        @Schema(description = "정식(또는 파종)일", example = "2024-02-25")
+        @Schema(description = "정식일", example = "2024-02-25")
         @NotNull
-        LocalDate plantingDate
+        LocalDate plantingDate,
+
+        @Schema(description = "수확 시작일", example = "2024-05-10")
+        @NotNull
+        LocalDate harvestStartDate,
+
+        @Schema(description = "수확 마감일", example = "2024-06-05")
+        @NotNull
+        LocalDate harvestEndDate
 ) {
     public UserCrop toEntity(Coordinates coordinates, User user) {
         Location cultivationLocation = Location.builder()
@@ -51,6 +59,8 @@ public record UserCropCreateRequest(
                 .cultivationLocation(cultivationLocation)
                 .cultivationArea(cultivationArea)
                 .plantingDate(plantingDate)
+                .harvestStartDate(harvestStartDate)
+                .harvestEndDate(harvestEndDate)
                 .user(user)
                 .build();
     }

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropUpdateRequest.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropUpdateRequest.java
@@ -34,9 +34,17 @@ public record UserCropUpdateRequest(
         @NotNull
         Integer cultivationArea,
 
-        @Schema(description = "정식(또는 파종)일", example = "2024-02-25")
+        @Schema(description = "정식일", example = "2024-02-25")
         @NotNull
-        LocalDate plantingDate
+        LocalDate plantingDate,
+
+        @Schema(description = "수확 시작일", example = "2024-05-10")
+        @NotNull
+        LocalDate harvestStartDate,
+
+        @Schema(description = "수확 마감일", example = "2024-06-05")
+        @NotNull
+        LocalDate harvestEndDate
 ) {
     public UserCrop toEntity(Coordinates coordinates, User user) {
         Location cultivationLocation = Location.builder()
@@ -51,6 +59,8 @@ public record UserCropUpdateRequest(
                 .cultivationLocation(cultivationLocation)
                 .cultivationArea(cultivationArea)
                 .plantingDate(plantingDate)
+                .harvestStartDate(harvestStartDate)
+                .harvestEndDate(harvestEndDate)
                 .user(user)
                 .build();
     }

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/response/UserCropDetailResponse.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/response/UserCropDetailResponse.java
@@ -28,8 +28,14 @@ public record UserCropDetailResponse(
         @Schema(description = "재배 면적", example = "1320")
         Integer cultivationArea,
 
-        @Schema(description = "정식(또는 파종)일", example = "2024-02-25")
-        LocalDate plantingDate
+        @Schema(description = "정식일", example = "2024-02-25")
+        LocalDate plantingDate,
+
+        @Schema(description = "수확 시작일", example = "2024-05-10")
+        LocalDate harvestStartDate,
+
+        @Schema(description = "수확 마감일", example = "2024-06-05")
+        LocalDate harvestEndDate
 ) {
     public static UserCropDetailResponse from(UserCrop userCrop) {
         return UserCropDetailResponse.builder()
@@ -40,6 +46,8 @@ public record UserCropDetailResponse(
                 .cultivationAddress(userCrop.getCultivationAddress())
                 .cultivationArea(userCrop.getCultivationArea())
                 .plantingDate(userCrop.getPlantingDate())
+                .harvestStartDate(userCrop.getHarvestStartDate())
+                .harvestEndDate(userCrop.getHarvestEndDate())
                 .build();
     }
 }

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/response/UserCropListResponse.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/response/UserCropListResponse.java
@@ -28,8 +28,14 @@ public record UserCropListResponse(
         @Schema(description = "재배 면적", example = "1320")
         Integer cultivationArea,
 
-        @Schema(description = "파종(정식)일", example = "2025-05-02")
-        LocalDate plantingDate
+        @Schema(description = "정식일", example = "2025-05-02")
+        LocalDate plantingDate,
+
+        @Schema(description = "수확 시작일", example = "2024-05-10")
+        LocalDate harvestStartDate,
+
+        @Schema(description = "수확 마감일", example = "2024-06-05")
+        LocalDate harvestEndDate
 ) {
     public static UserCropListResponse from(UserCrop userCrop) {
         return UserCropListResponse.builder()
@@ -40,6 +46,8 @@ public record UserCropListResponse(
                 .cultivationAddress(userCrop.getCultivationAddress())
                 .cultivationArea(userCrop.getCultivationArea())
                 .plantingDate(userCrop.getPlantingDate())
+                .harvestStartDate(userCrop.getHarvestStartDate())
+                .harvestEndDate(userCrop.getHarvestEndDate())
                 .build();
     }
 }


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 작물 저장 시 정식일, 수확시기(시작일, 마감일) 받도록 수정


## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 작물 수확 일정 관리: 각 작물별로 수확 시작일과 수확 마감일을 등록하거나 수정할 수 있는 기능이 추가되었습니다. 수확 예정 기간에 대한 정보는 작물 목록 조회와 상세 조회 화면 모두에서 확인할 수 있으며, 잘못된 날짜 입력 시 자동으로 검증되어 오류를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->