### PR TITLE
docs: 관심 시장 swagger 문서화 수정

### DIFF
--- a/src/main/java/kr/co/webee/presentation/market/dto/request/InterestMarketRegisterRequest.java
+++ b/src/main/java/kr/co/webee/presentation/market/dto/request/InterestMarketRegisterRequest.java
@@ -1,5 +1,6 @@
 package kr.co.webee.presentation.market.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import kr.co.webee.domain.market.entity.InterestMarket;
@@ -32,10 +33,12 @@ public record InterestMarketRegisterRequest(
                 .build();
     }
 
+    @JsonIgnore
     public boolean isMarketOnly() {
         return (cropMajorCode == null) && (cropMidName == null) && (cropMinorName == null);
     }
 
+    @JsonIgnore
     public boolean isMarketWithCrop() {
         return (cropMajorCode != null) && (cropMidName != null) && (cropMinorName != null);
     }


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 관심 시장 등록 request(`InterestMarketRegisterRequest`)에서 `isMarketOnly`와 `isMarketWithCrop` 메서드의 swagger 문서화 방지를 위한 @JsonIgnore 추가


## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

