### PR TITLE
test: 테스트 환경 개선 및 벌통 교체 기록 통합 테스트 추가

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,323 @@
+---
+name: test
+description: >
+  Spring Boot 프로젝트(was)의 테스트 코드를 자동으로 작성하고 JaCoCo 커버리지를 검증하는 스킬.
+  다음 상황에서 반드시 이 스킬을 사용한다:
+  "테스트 써줘", "테스트 코드 작성", "테스트 추가", "커버리지 올려줘", "JaCoCo", "테스트 보강",
+  "변경된 파일 테스트", "미커버 케이스", "test code", "coverage" 등의 요청.
+  변경된 소스 파일이 있고 테스트가 필요한 상황이라면 명시적 언급 없이도 이 스킬을 적용한다.
+---
+
+# Spring Test Generator
+
+이 프로젝트(현재 저장소 루트)의 테스트 코드를 작성하고 JaCoCo로 커버리지를 검증하는 자동화 스킬이다.
+
+## 전체 흐름
+
+```text
+1. 변경 파일 식별 → 2. 테스트 작성/보강 → 3. JaCoCo 검증 → (미달 시 2로 반복) → 4. 결과 리포트
+```
+
+---
+
+## STEP 1: 변경 파일 식별
+
+기본 브랜치 대비 변경된 소스 파일을 찾고, 테스트가 필요한 레이어만 필터링한다.
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+
+# 변경된 파일 목록 (기본 브랜치 대비)
+git diff --name-only $(git merge-base HEAD origin/main) HEAD -- 'src/main/java/**'
+# 또는 스테이징/언스테이징 포함
+git diff --name-only HEAD
+```
+
+### 레이어별 테스트 전략
+
+패키지 경로로 레이어를 판별한다:
+
+| 패키지 경로 | 레이어 | 테스트 방식 |
+|------------|--------|-----------|
+| `presentation/*/controller/` | Controller | `@WebMvcTest` |
+| `application/*/service/` | Service | `@IntegrationTest` |
+| `domain/*/repository/` | Repository | `@RepositoryTest` |
+| `domain/*/entity/` | Domain/Entity | 순수 JUnit (Spring 컨텍스트 없음) |
+
+**테스트 불필요 파일** (스킵):
+- `*/dto/**`, `*/request/**`, `*/response/**` — 단순 데이터 클래스
+- `*/config/**`, `*/common/**` — 설정 클래스
+- `*/enums/**`, `*/type/**` — 열거형
+
+---
+
+## STEP 2: 테스트 작성
+
+### 2-1. 기존 테스트 확인
+
+테스트 파일 경로: `src/main/java/kr/co/webee/X/Y.java` → `src/test/java/kr/co/webee/X/YTest.java`
+
+기존 파일이 있으면 미커버 케이스만 추가. 없으면 신규 작성.
+
+### 2-2. 공통 컨벤션 (반드시 준수)
+
+**Assertion**: AssertJ만 사용. JUnit5 `assertEquals`, `assertThrows`, `assertNotNull` 금지.
+
+```java
+// ✅ 올바른 방식
+assertThat(result).isEqualTo(expected);
+assertThat(result).isNotNull();
+assertThatThrownBy(() -> service.doSomething())
+        .isInstanceOf(BusinessException.class)
+        .extracting("type")
+        .isEqualTo(ErrorType.SOME_ERROR);
+
+// ❌ 금지
+assertEquals(expected, result);
+assertThrows(BusinessException.class, () -> ...);
+```
+
+**Import**: JUnit5 `Assertions.*` import 금지.
+```java
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+```
+
+**DisplayName**: `@DisplayName` 한국어 작성.
+- 성공: `"상품 리뷰를 등록한다."`
+- 실패: `"존재하지 않는 상품에 리뷰를 등록하려는 경우 예외가 발생한다."`
+
+**구조**:
+```java
+@Test
+@DisplayName("...")  // @Test 바로 아래
+void methodName() {
+    //given
+
+    //when
+
+    //then
+}
+
+// 예외 케이스는 when-then 통합 가능
+void failCase() {
+    //given
+
+    //when - then
+    assertThatThrownBy(...)...;
+}
+```
+
+**그룹핑**: 관련 테스트가 3개 이상이면 `@Nested` + `@DisplayName`으로 묶는다.
+```java
+@Nested
+@DisplayName("회원가입")
+class SignUp {
+    @Test
+    @DisplayName("성공")
+    void signUpSuccess() { ... }
+
+    @Test
+    @DisplayName("실패 - 동일한 아이디가 존재하는 경우")
+    void signUpFailSameUsername() { ... }
+}
+```
+
+**픽스처 헬퍼**: 반복 생성 객체는 `private` 메서드로 분리.
+```java
+private User createUser() {
+    return User.builder().username("test").password("pw").name("이름").build();
+}
+```
+
+### 2-3. 레이어별 템플릿
+
+#### Controller (`@WebMvcTest`)
+
+```java
+@WebMvcTest(
+        controllers = XxxController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OncePerRequestFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UserIdArgumentResolver.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)
+        }
+)
+@Import(TestWebConfig.class)
+@ActiveProfiles("test")
+class XxxControllerTest {
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockitoBean XxxService xxxService;
+
+    @Test
+    @DisplayName("...")
+    void test() throws Exception {
+        //given
+        when(xxxService.method(any())).thenReturn(response);
+
+        //when - then
+        mockMvc.perform(post("/api/v1/...")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                .andDo(print());
+    }
+}
+```
+
+#### Service (`@IntegrationTest`)
+
+```java
+@IntegrationTest
+class XxxServiceTest {
+    @Autowired XxxService xxxService;
+    @Autowired XxxRepository xxxRepository;
+
+    @BeforeEach
+    void setUp() {
+        // DB에 필요한 픽스처 저장
+    }
+
+    @Test
+    @DisplayName("...")
+    void test() {
+        //given
+        //when
+        //then
+    }
+}
+```
+
+#### Repository (`@RepositoryTest`)
+
+```java
+@RepositoryTest
+class XxxRepositoryTest {
+    @Autowired XxxRepository xxxRepository;
+
+    @Test
+    @DisplayName("...")
+    void test() {
+        //given
+        // 엔티티 저장
+
+        //when
+        List<Xxx> result = xxxRepository.findAllByXxx(...);
+
+        //then
+        assertThat(result).hasSize(2)
+                .extracting("field")
+                .containsExactlyInAnyOrder("value1", "value2");
+    }
+}
+```
+
+#### Entity/Domain (순수 JUnit)
+
+```java
+class XxxTest {
+    @Test
+    @DisplayName("...")
+    void test() {
+        //given
+        Xxx entity = createXxx();
+
+        //when
+        entity.updateSomething(newValue);
+
+        //then
+        assertThat(entity.getField()).isEqualTo(newValue);
+    }
+}
+```
+
+---
+
+## STEP 3: JaCoCo 검증
+
+### 3-1. 테스트 실행 및 리포트 생성
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+./gradlew test jacocoTestReport --tests "kr.co.webee.path.to.XxxTest"
+```
+
+특정 클래스만 빠르게 실행할 때:
+```bash
+./gradlew test --tests "kr.co.webee.*.XxxTest" jacocoTestReport
+```
+
+### 3-2. 커버리지 파싱
+
+HTML 리포트 위치: `build/reports/jacoco/test/html/`
+
+대상 클래스 리포트 경로 패턴:
+```text
+build/reports/jacoco/test/html/kr.co.webee.path/XxxClass.html
+```
+
+HTML에서 커버리지 추출:
+```bash
+# 미커버 라인/브랜치 확인 (class summary)
+grep -o 'Total[^<]*<td[^>]*>[0-9]*%' build/reports/jacoco/test/html/index.html
+
+# 특정 클래스 상세 (fc=covered, fc nc=missed)
+grep -c 'class="nc"' build/reports/jacoco/test/html/kr.co.webee.xxx/XxxClass.java.html
+```
+
+또는 XML 리포트가 있다면 더 간편:
+```bash
+# build/reports/jacoco/test/jacocoTestReport.xml
+grep 'name="XxxClass"' build/reports/jacoco/test/jacocoTestReport.xml
+```
+
+### 3-3. 목표 커버리지
+
+| 구분 | 라인 커버리지 | 브랜치 커버리지 |
+|------|------------|--------------|
+| Service | 80% 이상 | 70% 이상 |
+| Repository | 90% 이상 | — |
+| Controller | 80% 이상 | 60% 이상 |
+| Entity/Domain | 80% 이상 | 70% 이상 |
+
+미달 시 → STEP 2로 돌아가 미커버 라인/브랜치에 대응하는 케이스를 추가한다.
+
+---
+
+## STEP 4: 결과 리포트
+
+작업 완료 후 아래 형식으로 결과를 출력한다.
+
+```text
+## 테스트 작성 결과
+
+### 처리 대상 파일
+- `XxxService.java` → `XxxServiceTest.java` (신규 작성 / 보강)
+- `XxxController.java` → `XxxControllerTest.java` (신규 작성 / 보강)
+
+### 작성된 테스트 케이스
+| 파일 | 추가된 케이스 |
+|------|------------|
+| XxxServiceTest | "xxx를 등록한다.", "존재하지 않는 xxx 조회 시 예외 발생" 외 N건 |
+
+### JaCoCo 커버리지
+| 클래스 | 라인 | 브랜치 | 상태 |
+|--------|------|--------|------|
+| XxxService | 85% | 75% | ✅ |
+| XxxController | 78% | 65% | ✅ |
+
+### 미처리 항목
+- (있다면 사유와 함께 기록)
+```
+
+---
+
+## 주의사항
+
+- `@Transactional`은 `@IntegrationTest`, `@RepositoryTest`에서 이미 롤백 처리됨 — 별도 선언 불필요
+- `UserIdArgumentResolver`가 있는 Controller는 TestWebConfig로 모킹 필요
+- Testcontainers는 `@IntegrationTest`, `@RepositoryTest`에 이미 포함됨
+- AWS S3, FCM, AI 관련 빈은 `@IntegrationTest`의 TestConfig들로 이미 처리됨

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'kr.co'
@@ -110,6 +111,41 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                '**/dto/**',
+                '**/request/**',
+                '**/response/**',
+                '**/config/**',
+                '**/common/**',
+                '**/enums/**',
+                '**/type/**',
+                '**/*Application*',
+            ])
+        }))
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+        }
+    }
 }
 
 tasks.bootBuildImage.createdDate = "now"

--- a/src/test/java/kr/co/webee/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/webee/application/auth/service/AuthServiceTest.java
@@ -24,8 +24,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -85,8 +85,8 @@ class AuthServiceTest {
             //then
             verify(userRepository).save(userCaptor.capture());
 
-            assertEquals(request.username(), userCaptor.getValue().getUsername());
-            assertEquals(userCaptor.getValue().getName(), request.name());
+            assertThat(userCaptor.getValue().getUsername()).isEqualTo(request.username());
+            assertThat(userCaptor.getValue().getName()).isEqualTo(request.name());
         }
 
         @Test
@@ -97,11 +97,11 @@ class AuthServiceTest {
 
             when(userRepository.existsByUsername(request.username())).thenReturn(true);
 
-            //when
-            BusinessException exception = assertThrows(BusinessException.class, () -> authService.signup(request));
-
-            //then
-            assertEquals(ErrorType.ALREADY_EXIST_USERNAME, exception.getType());
+            //when - then
+            assertThatThrownBy(() -> authService.signup(request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.ALREADY_EXIST_USERNAME);
         }
     }
 
@@ -125,11 +125,11 @@ class AuthServiceTest {
             SignInDto response = authService.signIn(request);
 
             //then
-            assertNotNull(response);
-            assertEquals(response.name(),"name");
+            assertThat(response).isNotNull();
+            assertThat(response.name()).isEqualTo("name");
             JwtTokenDto token = response.jwtTokenDto();
-            assertEquals("accessToken", token.accessToken());
-            assertEquals("refreshToken", token.refreshToken());
+            assertThat(token.accessToken()).isEqualTo("accessToken");
+            assertThat(token.refreshToken()).isEqualTo("refreshToken");
         }
 
         @Test
@@ -138,11 +138,11 @@ class AuthServiceTest {
             //given
             when(userRepository.findByUsername(request.username())).thenReturn(Optional.empty());
 
-            //when
-            BusinessException exception = assertThrows(BusinessException.class, () -> authService.signIn(request));
-
-            //then
-            assertEquals(exception.getType(), ErrorType.INVALID_CREDENTIALS);
+            //when - then
+            assertThatThrownBy(() -> authService.signIn(request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.INVALID_CREDENTIALS);
         }
 
         @Test
@@ -152,11 +152,11 @@ class AuthServiceTest {
             when(userRepository.findByUsername(request.username())).thenReturn(Optional.of(user));
             when(passwordEncoder.matches(request.password(), user.getPassword())).thenReturn(false);
 
-            //when
-            BusinessException exception = assertThrows(BusinessException.class, () -> authService.signIn(request));
-
-            // then
-            assertEquals(exception.getType(), ErrorType.FAILED_AUTHENTICATION);
+            //when - then
+            assertThatThrownBy(() -> authService.signIn(request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.FAILED_AUTHENTICATION);
         }
     }
 }

--- a/src/test/java/kr/co/webee/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/webee/application/auth/service/AuthServiceTest.java
@@ -9,6 +9,7 @@ import kr.co.webee.domain.user.entity.User;
 import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.presentation.auth.dto.request.SignInRequest;
 import kr.co.webee.presentation.auth.dto.request.SignUpRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,11 @@ class AuthServiceTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void cleanUp() {
+        userRepository.deleteAll();
+    }
 
     @Nested
     @DisplayName("회원가입")

--- a/src/test/java/kr/co/webee/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/webee/application/auth/service/AuthServiceTest.java
@@ -1,62 +1,34 @@
 package kr.co.webee.application.auth.service;
 
+import kr.co.webee.annotation.IntegrationTest;
 import kr.co.webee.application.auth.dto.JwtTokenDto;
 import kr.co.webee.application.auth.dto.SignInDto;
-import kr.co.webee.application.auth.helper.JwtHelper;
-import kr.co.webee.common.auth.jwt.JwtProvider;
 import kr.co.webee.common.error.ErrorType;
 import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.user.entity.User;
 import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.presentation.auth.dto.request.SignInRequest;
 import kr.co.webee.presentation.auth.dto.request.SignUpRequest;
-import kr.co.webee.application.user.service.UserService;
-import kr.co.webee.domain.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@IntegrationTest
 class AuthServiceTest {
-    @Mock
-    private JwtHelper jwtHelper;
 
-    @Mock
-    private PasswordEncoder passwordEncoder;
-
-    @Mock
-    private JwtProvider jwtProvider;
-
-    @Mock
-    private RefreshTokenService refreshTokenService;
-
-    @Mock
-    private UserRepository userRepository;
-
-    @InjectMocks
+    @Autowired
     private AuthService authService;
 
-    private final User user = User.builder()
-            .username("username")
-            .password("encodedPassword")
-            .name("name")
-            .build();
+    @Autowired
+    private UserRepository userRepository;
 
-    private final JwtTokenDto jwtTokenDto = JwtTokenDto.of("accessToken", "refreshToken");
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Nested
     @DisplayName("회원가입")
@@ -67,35 +39,23 @@ class AuthServiceTest {
                 .name("name")
                 .build();
 
-        @Captor
-        private ArgumentCaptor<User> userCaptor;
-
         @Test
         @DisplayName("성공")
         void signUpSuccess() {
-            //given
-            String encodedPassword = "encodedPassword";
-
-            when(userRepository.existsByUsername(request.username())).thenReturn(false);
-            when(passwordEncoder.encode("password")).thenReturn(encodedPassword);
-
             //when
             authService.signup(request);
 
             //then
-            verify(userRepository).save(userCaptor.capture());
-
-            assertThat(userCaptor.getValue().getUsername()).isEqualTo(request.username());
-            assertThat(userCaptor.getValue().getName()).isEqualTo(request.name());
+            User savedUser = userRepository.findByUsername(request.username()).orElseThrow();
+            assertThat(savedUser.getUsername()).isEqualTo(request.username());
+            assertThat(savedUser.getName()).isEqualTo(request.name());
         }
 
         @Test
         @DisplayName("실패 - 동일한 아이디를 가진 사용자가 존재하는 경우")
         void signUpFailSameUsername() {
             //given
-            String encodedPassword = "encodedPassword";
-
-            when(userRepository.existsByUsername(request.username())).thenReturn(true);
+            authService.signup(request);
 
             //when - then
             assertThatThrownBy(() -> authService.signup(request))
@@ -108,18 +68,22 @@ class AuthServiceTest {
     @Nested
     @DisplayName("로그인")
     class SignIn {
+        private final String rawPassword = "password";
+
         private final SignInRequest request = SignInRequest.builder()
                 .username("username")
-                .password("password")
+                .password(rawPassword)
                 .build();
 
         @Test
         @DisplayName("성공")
         void signInSuccess() {
             //given
-            when(userRepository.findByUsername(request.username())).thenReturn(Optional.of(user));
-            when(passwordEncoder.matches("password", user.getPassword())).thenReturn(true);
-            when(jwtHelper.createToken(any(), any())).thenReturn(jwtTokenDto);
+            userRepository.save(User.builder()
+                    .username("username")
+                    .password(passwordEncoder.encode(rawPassword))
+                    .name("name")
+                    .build());
 
             //when
             SignInDto response = authService.signIn(request);
@@ -128,16 +92,13 @@ class AuthServiceTest {
             assertThat(response).isNotNull();
             assertThat(response.name()).isEqualTo("name");
             JwtTokenDto token = response.jwtTokenDto();
-            assertThat(token.accessToken()).isEqualTo("accessToken");
-            assertThat(token.refreshToken()).isEqualTo("refreshToken");
+            assertThat(token.accessToken()).isNotNull();
+            assertThat(token.refreshToken()).isNotNull();
         }
 
         @Test
         @DisplayName("실패 - 아이디가 존재하지 않는 경우")
         void signInFailNotFoundUsername() {
-            //given
-            when(userRepository.findByUsername(request.username())).thenReturn(Optional.empty());
-
             //when - then
             assertThatThrownBy(() -> authService.signIn(request))
                     .isInstanceOf(BusinessException.class)
@@ -149,8 +110,11 @@ class AuthServiceTest {
         @DisplayName("실패 - 비밀번호가 일치하지 않는 경우")
         void signInFailPasswordMismatch() {
             //given
-            when(userRepository.findByUsername(request.username())).thenReturn(Optional.of(user));
-            when(passwordEncoder.matches(request.password(), user.getPassword())).thenReturn(false);
+            userRepository.save(User.builder()
+                    .username("username")
+                    .password(passwordEncoder.encode("differentPassword"))
+                    .name("name")
+                    .build());
 
             //when - then
             assertThatThrownBy(() -> authService.signIn(request))

--- a/src/test/java/kr/co/webee/application/hive/service/HiveReplacementHistoryServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveReplacementHistoryServiceTest.java
@@ -1,0 +1,448 @@
+package kr.co.webee.application.hive.service;
+
+import kr.co.webee.annotation.IntegrationTest;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.entity.HiveReplacementHistory;
+import kr.co.webee.domain.hive.repository.HiveRepository;
+import kr.co.webee.domain.hive.repository.HiveReplacementHistoryRepository;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
+import kr.co.webee.presentation.hive.dto.request.HiveReplacementHistoryCreateRequest;
+import kr.co.webee.presentation.hive.dto.request.HiveReplacementHistoryUpdateRequest;
+import kr.co.webee.presentation.hive.dto.response.HiveReplacementHistoryCreateResponse;
+import kr.co.webee.presentation.hive.dto.response.HiveReplacementHistoryDetailResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class HiveReplacementHistoryServiceTest {
+
+    @Autowired
+    private HiveReplacementHistoryService hiveReplacementHistoryService;
+
+    @Autowired
+    private HiveReplacementHistoryRepository hiveReplacementHistoryRepository;
+
+    @Autowired
+    private HiveRepository hiveRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+    private Hive hive;
+
+    private static int seq = 0;
+
+    @BeforeEach
+    void setUp() {
+        seq++;
+        user = userRepository.save(
+                User.builder()
+                        .username("hive-user-" + seq)
+                        .password("password")
+                        .name("테스트유저")
+                        .businessRegistered(false)
+                        .build()
+        );
+        hive = hiveRepository.save(
+                Hive.builder()
+                        .macAddress(String.format("AA:BB:CC:DD:EE:%02X", seq))
+                        .name("테스트 벌통")
+                        .region("서울")
+                        .location("강남구")
+                        .user(user)
+                        .build()
+        );
+    }
+
+    @Nested
+    @DisplayName("교체 기록 등록")
+    class CreateReplacementHistory {
+
+        @Test
+        @DisplayName("최초 교체 기록을 등록한다.")
+        void createFirstHistory() {
+            //given
+            LocalDate replacedAt = LocalDate.of(2025, 1, 1);
+            HiveReplacementHistoryCreateRequest request = new HiveReplacementHistoryCreateRequest(replacedAt);
+
+            //when
+            HiveReplacementHistoryCreateResponse response =
+                    hiveReplacementHistoryService.createReplacementHistory(hive.getId(), user.getId(), request);
+
+            //then
+            assertThat(response.replacementHistoryId()).isNotNull();
+
+            HiveReplacementHistory saved = hiveReplacementHistoryRepository.findById(response.replacementHistoryId()).orElseThrow();
+            assertThat(saved.getReplacedAt()).isEqualTo(replacedAt);
+            assertThat(saved.getUsageDays()).isNull();
+        }
+
+        @Test
+        @DisplayName("두 번째 교체 기록 등록 시 이전 기록의 사용 일수가 업데이트된다.")
+        void createSecondHistoryUpdatesPreviousUsageDays() {
+            //given
+            LocalDate firstDate = LocalDate.of(2025, 1, 1);
+            LocalDate secondDate = LocalDate.of(2025, 2, 1);
+
+            HiveReplacementHistory firstHistory = createHistory(hive, firstDate);
+            HiveReplacementHistoryCreateRequest request = new HiveReplacementHistoryCreateRequest(secondDate);
+
+            //when
+            hiveReplacementHistoryService.createReplacementHistory(hive.getId(), user.getId(), request);
+
+            //then
+            HiveReplacementHistory updatedFirst = hiveReplacementHistoryRepository.findById(firstHistory.getId()).orElseThrow();
+            long expectedUsageDays = ChronoUnit.DAYS.between(firstDate, secondDate);
+            assertThat(updatedFirst.getUsageDays()).isEqualTo(expectedUsageDays);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통에 교체 기록을 등록하려는 경우 예외가 발생한다.")
+        void createHistoryWithNotFoundHive() {
+            //given
+            Long notFoundHiveId = -1L;
+            HiveReplacementHistoryCreateRequest request = new HiveReplacementHistoryCreateRequest(LocalDate.of(2025, 1, 1));
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.createReplacementHistory(notFoundHiveId, user.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("최신 교체 기록의 날짜와 동일하거나 이전 날짜로 등록하려는 경우 예외가 발생한다.")
+        void createHistoryWithInvalidDate() {
+            //given
+            createHistory(hive, LocalDate.of(2025, 3, 1));
+            HiveReplacementHistoryCreateRequest request = new HiveReplacementHistoryCreateRequest(LocalDate.of(2025, 2, 1));
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.createReplacementHistory(hive.getId(), user.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_REPLACEMENT_HISTORY_INVALID_DATE);
+        }
+    }
+
+    @Nested
+    @DisplayName("교체 기록 상세 조회")
+    class GetReplacementHistoryDetail {
+
+        @Test
+        @DisplayName("사용 일수가 설정된 교체 기록 상세를 조회한다.")
+        void getDetailWithUsageDays() {
+            //given
+            LocalDate firstDate = LocalDate.of(2025, 1, 1);
+            LocalDate secondDate = LocalDate.of(2025, 2, 10);
+            HiveReplacementHistory firstHistory = createHistory(hive, firstDate);
+            firstHistory.updateUsageDays(ChronoUnit.DAYS.between(firstDate, secondDate));
+            hiveReplacementHistoryRepository.save(firstHistory);
+
+            //when
+            HiveReplacementHistoryDetailResponse response =
+                    hiveReplacementHistoryService.getReplacementHistoryDetail(hive.getId(), firstHistory.getId(), user.getId());
+
+            //then
+            assertThat(response.replacementHistoryId()).isEqualTo(firstHistory.getId());
+            assertThat(response.replacedAt()).isEqualTo(firstDate);
+            assertThat(response.usageDays()).isEqualTo(ChronoUnit.DAYS.between(firstDate, secondDate));
+        }
+
+        @Test
+        @DisplayName("사용 일수가 null인 최신 교체 기록 조회 시 오늘까지의 일수를 반환한다.")
+        void getDetailWithNullUsageDays() {
+            //given
+            LocalDate replacedAt = LocalDate.of(2025, 6, 1);
+            HiveReplacementHistory history = createHistory(hive, replacedAt);
+
+            //when
+            HiveReplacementHistoryDetailResponse response =
+                    hiveReplacementHistoryService.getReplacementHistoryDetail(hive.getId(), history.getId(), user.getId());
+
+            //then
+            long expectedUsageDays = ChronoUnit.DAYS.between(replacedAt, LocalDate.now());
+            assertThat(response.usageDays()).isEqualTo(expectedUsageDays);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통의 교체 기록을 조회하려는 경우 예외가 발생한다.")
+        void getDetailWithNotFoundHive() {
+            //given
+            Long notFoundHiveId = -1L;
+            HiveReplacementHistory history = createHistory(hive, LocalDate.of(2025, 1, 1));
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.getReplacementHistoryDetail(notFoundHiveId, history.getId(), user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 교체 기록을 조회하려는 경우 예외가 발생한다.")
+        void getDetailWithNotFoundHistory() {
+            //given
+            Long notFoundHistoryId = -1L;
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.getReplacementHistoryDetail(hive.getId(), notFoundHistoryId, user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_REPLACEMENT_HISTORY_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("교체 기록 목록 조회")
+    class GetAllReplacementHistories {
+
+        @Test
+        @DisplayName("벌통의 교체 기록 목록을 조회한다.")
+        void getAllHistories() {
+            //given
+            createHistory(hive, LocalDate.of(2025, 1, 1));
+            createHistory(hive, LocalDate.of(2025, 2, 1));
+            createHistory(hive, LocalDate.of(2025, 3, 1));
+
+            //when
+            Slice<?> result = hiveReplacementHistoryService.getAllReplacementHistories(
+                    hive.getId(), user.getId(), PageRequest.of(0, 10));
+
+            //then
+            assertThat(result.getContent()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통의 교체 기록 목록을 조회하려는 경우 예외가 발생한다.")
+        void getAllHistoriesWithNotFoundHive() {
+            //given
+            Long notFoundHiveId = -1L;
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.getAllReplacementHistories(
+                            notFoundHiveId, user.getId(), PageRequest.of(0, 10)))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("교체 기록 수정")
+    class UpdateReplacementHistory {
+
+        @Test
+        @DisplayName("단일 교체 기록의 날짜를 수정한다.")
+        void updateSingleHistory() {
+            //given
+            HiveReplacementHistory history = createHistory(hive, LocalDate.of(2025, 1, 1));
+            LocalDate newDate = LocalDate.of(2025, 1, 15);
+            HiveReplacementHistoryUpdateRequest request = new HiveReplacementHistoryUpdateRequest(newDate);
+
+            //when
+            hiveReplacementHistoryService.updateReplacementHistory(hive.getId(), history.getId(), user.getId(), request);
+
+            //then
+            HiveReplacementHistory updated = hiveReplacementHistoryRepository.findById(history.getId()).orElseThrow();
+            assertThat(updated.getReplacedAt()).isEqualTo(newDate);
+        }
+
+        @Test
+        @DisplayName("이전/이후 기록이 있을 때 수정하면 이전 기록과 현재 기록의 사용 일수가 재계산된다.")
+        void updateMiddleHistoryRecalculatesUsageDays() {
+            //given
+            LocalDate olderDate = LocalDate.of(2025, 1, 1);
+            LocalDate targetDate = LocalDate.of(2025, 2, 1);
+            LocalDate newerDate = LocalDate.of(2025, 3, 1);
+
+            HiveReplacementHistory olderHistory = createHistory(hive, olderDate);
+            HiveReplacementHistory targetHistory = createHistory(hive, targetDate);
+            createHistory(hive, newerDate);
+
+            LocalDate updatedDate = LocalDate.of(2025, 2, 15);
+            HiveReplacementHistoryUpdateRequest request = new HiveReplacementHistoryUpdateRequest(updatedDate);
+
+            //when
+            hiveReplacementHistoryService.updateReplacementHistory(hive.getId(), targetHistory.getId(), user.getId(), request);
+
+            //then
+            HiveReplacementHistory updatedOlder = hiveReplacementHistoryRepository.findById(olderHistory.getId()).orElseThrow();
+            HiveReplacementHistory updatedTarget = hiveReplacementHistoryRepository.findById(targetHistory.getId()).orElseThrow();
+
+            assertThat(updatedOlder.getUsageDays()).isEqualTo(ChronoUnit.DAYS.between(olderDate, updatedDate));
+            assertThat(updatedTarget.getUsageDays()).isEqualTo(ChronoUnit.DAYS.between(updatedDate, newerDate));
+            assertThat(updatedTarget.getReplacedAt()).isEqualTo(updatedDate);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통의 교체 기록을 수정하려는 경우 예외가 발생한다.")
+        void updateWithNotFoundHive() {
+            //given
+            HiveReplacementHistory history = createHistory(hive, LocalDate.of(2025, 1, 1));
+            Long notFoundHiveId = -1L;
+            HiveReplacementHistoryUpdateRequest request = new HiveReplacementHistoryUpdateRequest(LocalDate.of(2025, 1, 15));
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.updateReplacementHistory(notFoundHiveId, history.getId(), user.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 교체 기록을 수정하려는 경우 예외가 발생한다.")
+        void updateNotFoundHistory() {
+            //given
+            Long notFoundHistoryId = -1L;
+            HiveReplacementHistoryUpdateRequest request = new HiveReplacementHistoryUpdateRequest(LocalDate.of(2025, 1, 15));
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.updateReplacementHistory(hive.getId(), notFoundHistoryId, user.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_REPLACEMENT_HISTORY_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("이전 기록의 날짜와 동일하거나 이전 날짜로 수정하려는 경우 예외가 발생한다.")
+        void updateWithDateBeforeOrEqualOlderHistory() {
+            //given
+            createHistory(hive, LocalDate.of(2025, 1, 1));
+            HiveReplacementHistory targetHistory = createHistory(hive, LocalDate.of(2025, 3, 1));
+            HiveReplacementHistoryUpdateRequest request = new HiveReplacementHistoryUpdateRequest(LocalDate.of(2025, 1, 1));
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.updateReplacementHistory(hive.getId(), targetHistory.getId(), user.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_REPLACEMENT_HISTORY_INVALID_DATE);
+        }
+
+        @Test
+        @DisplayName("이후 기록의 날짜와 동일하거나 이후 날짜로 수정하려는 경우 예외가 발생한다.")
+        void updateWithDateAfterOrEqualNewerHistory() {
+            //given
+            HiveReplacementHistory targetHistory = createHistory(hive, LocalDate.of(2025, 1, 1));
+            createHistory(hive, LocalDate.of(2025, 3, 1));
+            HiveReplacementHistoryUpdateRequest request = new HiveReplacementHistoryUpdateRequest(LocalDate.of(2025, 3, 1));
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.updateReplacementHistory(hive.getId(), targetHistory.getId(), user.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_REPLACEMENT_HISTORY_INVALID_DATE);
+        }
+    }
+
+    @Nested
+    @DisplayName("교체 기록 삭제")
+    class DeleteReplacementHistory {
+
+        @Test
+        @DisplayName("최신 교체 기록을 삭제하면 이전 기록의 사용 일수가 null로 초기화된다.")
+        void deleteLatestHistoryClearsOlderUsageDays() {
+            //given
+            LocalDate olderDate = LocalDate.of(2025, 1, 1);
+            LocalDate latestDate = LocalDate.of(2025, 2, 1);
+
+            HiveReplacementHistory olderHistory = createHistory(hive, olderDate);
+            olderHistory.updateUsageDays(ChronoUnit.DAYS.between(olderDate, latestDate));
+            hiveReplacementHistoryRepository.save(olderHistory);
+
+            HiveReplacementHistory latestHistory = createHistory(hive, latestDate);
+
+            //when
+            hiveReplacementHistoryService.deleteReplacementHistory(hive.getId(), latestHistory.getId(), user.getId());
+
+            //then
+            assertThat(hiveReplacementHistoryRepository.existsById(latestHistory.getId())).isFalse();
+            HiveReplacementHistory updatedOlder = hiveReplacementHistoryRepository.findById(olderHistory.getId()).orElseThrow();
+            assertThat(updatedOlder.getUsageDays()).isNull();
+        }
+
+        @Test
+        @DisplayName("중간 교체 기록을 삭제하면 이전 기록의 사용 일수가 재계산된다.")
+        void deleteMiddleHistoryRecalculatesOlderUsageDays() {
+            //given
+            LocalDate olderDate = LocalDate.of(2025, 1, 1);
+            LocalDate middleDate = LocalDate.of(2025, 2, 1);
+            LocalDate newerDate = LocalDate.of(2025, 3, 1);
+
+            HiveReplacementHistory olderHistory = createHistory(hive, olderDate);
+            HiveReplacementHistory middleHistory = createHistory(hive, middleDate);
+            createHistory(hive, newerDate);
+
+            //when
+            hiveReplacementHistoryService.deleteReplacementHistory(hive.getId(), middleHistory.getId(), user.getId());
+
+            //then
+            assertThat(hiveReplacementHistoryRepository.existsById(middleHistory.getId())).isFalse();
+            HiveReplacementHistory updatedOlder = hiveReplacementHistoryRepository.findById(olderHistory.getId()).orElseThrow();
+            long expectedUsageDays = ChronoUnit.DAYS.between(olderDate, newerDate);
+            assertThat(updatedOlder.getUsageDays()).isEqualTo(expectedUsageDays);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통의 교체 기록을 삭제하려는 경우 예외가 발생한다.")
+        void deleteWithNotFoundHive() {
+            //given
+            HiveReplacementHistory history = createHistory(hive, LocalDate.of(2025, 1, 1));
+            Long notFoundHiveId = -1L;
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.deleteReplacementHistory(notFoundHiveId, history.getId(), user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 교체 기록을 삭제하려는 경우 예외가 발생한다.")
+        void deleteNotFoundHistory() {
+            //given
+            Long notFoundHistoryId = -1L;
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveReplacementHistoryService.deleteReplacementHistory(hive.getId(), notFoundHistoryId, user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_REPLACEMENT_HISTORY_NOT_FOUND);
+        }
+    }
+
+    private HiveReplacementHistory createHistory(Hive targetHive, LocalDate replacedAt) {
+        return hiveReplacementHistoryRepository.save(
+                HiveReplacementHistory.builder()
+                        .hive(targetHive)
+                        .replacedAt(replacedAt)
+                        .build()
+        );
+    }
+}

--- a/src/test/java/kr/co/webee/application/hive/service/HiveReplacementHistoryServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveReplacementHistoryServiceTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 
@@ -45,14 +44,15 @@ class HiveReplacementHistoryServiceTest {
     private User user;
     private Hive hive;
 
-    private static int seq = 0;
-
     @BeforeEach
     void setUp() {
-        seq++;
+        hiveReplacementHistoryRepository.deleteAll();
+        hiveRepository.deleteAll();
+        userRepository.deleteAll();
+
         user = userRepository.save(
                 User.builder()
-                        .username("hive-user-" + seq)
+                        .username("hive-user")
                         .password("password")
                         .name("테스트유저")
                         .businessRegistered(false)
@@ -60,7 +60,7 @@ class HiveReplacementHistoryServiceTest {
         );
         hive = hiveRepository.save(
                 Hive.builder()
-                        .macAddress(String.format("AA:BB:CC:DD:EE:%02X", seq))
+                        .macAddress("AA:BB:CC:DD:EE:FF")
                         .name("테스트 벌통")
                         .region("서울")
                         .location("강남구")

--- a/src/test/java/kr/co/webee/application/product/service/ProductReviewServiceTest.java
+++ b/src/test/java/kr/co/webee/application/product/service/ProductReviewServiceTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -55,6 +54,11 @@ class ProductReviewServiceTest {
 
     @BeforeEach
     void setUp() {
+        productReviewRepository.deleteAll();
+        productRepository.deleteAll();
+        businessRepository.deleteAll();
+        userRepository.deleteAll();
+
         User owner = User.builder().username("ownerUsername").password("ownerPassword").name("ownerName").businessRegistered(false).build();
         userRepository.save(owner);
 

--- a/src/test/java/kr/co/webee/domain/product/repository/ProductReviewRepositoryTest.java
+++ b/src/test/java/kr/co/webee/domain/product/repository/ProductReviewRepositoryTest.java
@@ -21,7 +21,6 @@ import static kr.co.webee.domain.product.enums.Origin.DOMESTIC;
 import static kr.co.webee.domain.product.enums.TransactionMethod.OFFLINE;
 import static kr.co.webee.domain.product.enums.TransactionType.PURCHASE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @RepositoryTest
 class ProductReviewRepositoryTest {

--- a/src/test/java/kr/co/webee/domain/profile/crop/entity/UserCropTest.java
+++ b/src/test/java/kr/co/webee/domain/profile/crop/entity/UserCropTest.java
@@ -9,7 +9,6 @@ import org.springframework.cglib.core.Local;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class UserCropTest {
 


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 84eb914 — JUnit5 assertEquals → AssertJ assertThat 스타일로 전체 통일
- 93c3195 — AuthServiceTest를 Mock 기반에서 실제 DB 띄우는 통합 테스트로 전환
- 83193e3 — 테스트 작성 절차·컨벤션·JaCoCo 검증 플로우를 담은 Claude Skill 문서 추가                                
- 294c811 — build.gradle에 JaCoCo 플러그인·리포트·커버리지 검증 태스크 설정                                         
- b389b58 — HiveReplacementHistoryService CRUD 전 케이스 통합 테스트 20건 작성


## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 인증 및 벌통 교체 기록 서비스에 대한 통합 테스트 추가
  * 테스트 코드 import 정렬 및 정규화

* **Chores**
  * JaCoCo 코드 커버리지 검증 인프라 구축 (최소 80% 라인 커버리지)
  * 테스트 실행 및 커버리지 보고서 자동 생성 설정
  * Spring Boot 프로젝트 테스트 작성 및 검증 표준 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->