### PR TITLE
fix: 작물 등록/수정 시 정식일을 선택으로 입력하도록 수정

### DIFF
--- a/src/main/java/kr/co/webee/domain/profile/crop/entity/UserCrop.java
+++ b/src/main/java/kr/co/webee/domain/profile/crop/entity/UserCrop.java
@@ -37,7 +37,7 @@ public class UserCrop extends BaseTimeEntity {
     @Column(nullable = false)
     private Integer cultivationArea;
 
-    @Column(nullable = false)
+    @Column
     private LocalDate plantingDate;
 
     @Column
@@ -63,7 +63,7 @@ public class UserCrop extends BaseTimeEntity {
         this.cultivationType = Objects.requireNonNull(cultivationType, "cultivationType은 null이 될 수 없습니다.");
         this.cultivationLocation =Objects.requireNonNull(cultivationLocation,"cultivationLocation은 null이 될 수 없습니다.");
         this.cultivationArea = Objects.requireNonNull(cultivationArea, "cultivationArea는 null이 될 수 없습니다.");
-        this.plantingDate = Objects.requireNonNull(plantingDate, "plantingDate는 null이 될 수 없습니다.");
+        this.plantingDate = plantingDate;
         this.harvestStartDate = Objects.requireNonNull(harvestStartDate, "harvestStartDate는 null이 될 수 없습니다.");
         this.harvestEndDate  = Objects.requireNonNull(harvestEndDate, "harvestEndDate는 null이 될 수 없습니다.");
         if (harvestStartDate.isAfter(harvestEndDate)) {
@@ -83,7 +83,7 @@ public class UserCrop extends BaseTimeEntity {
         this.variety = variety;
         this.cultivationType = Objects.requireNonNull(cultivationType, "cultivationType은 null이 될 수 없습니다.");
         this.cultivationArea = Objects.requireNonNull(cultivationArea, "cultivationArea는 null이 될 수 없습니다.");
-        this.plantingDate = Objects.requireNonNull(plantingDate, "plantingDate는 null이 될 수 없습니다.");
+        this.plantingDate = plantingDate;
         this.harvestStartDate = Objects.requireNonNull(harvestStartDate, "harvestStartDate는 null이 될 수 없습니다.");
         this.harvestEndDate  = Objects.requireNonNull(harvestEndDate, "harvestEndDate는 null이 될 수 없습니다.");
         if (harvestStartDate.isAfter(harvestEndDate)) {

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropCreateRequest.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropCreateRequest.java
@@ -35,7 +35,6 @@ public record UserCropCreateRequest(
         Integer cultivationArea,
 
         @Schema(description = "정식일", example = "2024-02-25")
-        @NotNull
         LocalDate plantingDate,
 
         @Schema(description = "수확 시작일", example = "2024-05-10")

--- a/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropUpdateRequest.java
+++ b/src/main/java/kr/co/webee/presentation/profile/crop/dto/request/UserCropUpdateRequest.java
@@ -35,7 +35,6 @@ public record UserCropUpdateRequest(
         Integer cultivationArea,
 
         @Schema(description = "정식일", example = "2024-02-25")
-        @NotNull
         LocalDate plantingDate,
 
         @Schema(description = "수확 시작일", example = "2024-05-10")


### PR DESCRIPTION
## 🧷 이슈

<!--  ex) #이슈 번호 -->

- close #

## 🔨 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 4ef736d 작물 등록/수정 시 정식일을 선택으로 입력하도록 수정


## 👀 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 작물 등록 및 수정 시 심기일 필드를 선택사항으로 변경했습니다. 사용자는 이제 심기일을 입력하지 않고도 작물 정보를 등록하거나 수정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->