### PR TITLE
feat: 벌통 개폐기 동작 API

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -123,12 +123,29 @@ class SignUp {
 }
 ```
 
-**픽스처 헬퍼**: 반복 생성 객체는 `private` 메서드로 분리.
+**픽스처 헬퍼**: 반복 생성 객체는 `TestFixture`를 우선 사용한다. 없으면 `private` 메서드로 분리.
+
+`TestFixture` 위치: `src/test/java/kr/co/webee/support/util/TestFixture.java`
+
+- 파라미터가 `null`이면 기본값을 사용하는 null-safe 팩토리 메서드 패턴
+- 여러 테스트 클래스에서 공유하는 엔티티 생성 로직을 중앙화
+
 ```java
-private User createUser() {
-    return User.builder().username("test").password("pw").name("이름").build();
+// TestFixture 사용 예시
+User user = TestFixture.createUser("gate-user");           // username 지정
+Hive hive = TestFixture.createHive(null, user);            // macAddress는 기본값
+HiveGateAction action = TestFixture.createHiveGateAction(null, GateActionType.OPEN_ONLY, null, hive);
+
+// TestFixture 메서드 구조
+public static Xxx createXxx(String field, ...) {
+    return Xxx.builder()
+            .field(field != null ? field : "기본값")
+            ...
+            .build();
 }
 ```
+
+새로운 엔티티에 대한 픽스처가 필요하면 `TestFixture`에 추가한다.
 
 ### 2-3. 레이어별 템플릿
 

--- a/src/main/java/kr/co/webee/application/hive/dto/request/HiveGateActionRegisterRequest.java
+++ b/src/main/java/kr/co/webee/application/hive/dto/request/HiveGateActionRegisterRequest.java
@@ -1,0 +1,38 @@
+package kr.co.webee.application.hive.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+import kr.co.webee.domain.hive.type.GateActionType;
+
+import java.time.LocalTime;
+
+@Schema(description = "개폐기 동작 등록 request")
+public record HiveGateActionRegisterRequest(
+        @Schema(description = "개폐기 동작 제목", example = "새벽 환기")
+        @NotBlank
+        String title,
+
+        @Schema(description = "개폐기 동작 유형", example = "OPEN_ONLY")
+        @NotNull
+        GateActionType actionType,
+
+        @Schema(description = "동작 시각", example = "09:00:00")
+        @NotNull
+        LocalTime actionTime,
+
+        @Schema(description = "반복 활성화 여부", example = "false")
+        boolean repeatEnabled
+) {
+    public HiveGateAction toEntity(Hive hive) {
+        return HiveGateAction.builder()
+                .hive(hive)
+                .title(title)
+                .actionType(actionType)
+                .actionTime(actionTime)
+                .repeatEnabled(repeatEnabled)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/application/hive/dto/request/HiveGateActionUpdateRequest.java
+++ b/src/main/java/kr/co/webee/application/hive/dto/request/HiveGateActionUpdateRequest.java
@@ -1,0 +1,27 @@
+package kr.co.webee.application.hive.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.co.webee.domain.hive.type.GateActionType;
+
+import java.time.LocalTime;
+
+@Schema(description = "개폐기 동작 수정 요청")
+public record HiveGateActionUpdateRequest(
+        @NotBlank
+        @Schema(description = "제목", example = "새벽 환기")
+        String title,
+
+        @NotNull
+        @Schema(description = "동작 유형", example = "OPEN_ONLY")
+        GateActionType actionType,
+
+        @NotNull
+        @Schema(description = "동작 시각", example = "09:00:00")
+        LocalTime actionTime,
+
+        @Schema(description = "반복 활성화 여부", example = "false")
+        boolean repeatEnabled
+) {
+}

--- a/src/main/java/kr/co/webee/application/hive/dto/response/HiveGateActionDetailResponse.java
+++ b/src/main/java/kr/co/webee/application/hive/dto/response/HiveGateActionDetailResponse.java
@@ -1,0 +1,37 @@
+package kr.co.webee.application.hive.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+import kr.co.webee.domain.hive.type.GateActionType;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+@Schema(description = "개폐기 동작 단건 조회 응답")
+public record HiveGateActionDetailResponse(
+        @Schema(description = "개폐기 동작 ID", example = "1")
+        Long id,
+
+        @Schema(description = "제목", example = "새벽 환기")
+        String title,
+
+        @Schema(description = "동작 유형", example = "OPEN_ONLY")
+        GateActionType actionType,
+
+        @Schema(description = "동작 시각", example = "09:00:00")
+        LocalTime actionTime,
+
+        @Schema(description = "반복 활성화 여부", example = "false")
+        boolean repeatEnabled
+) {
+    public static HiveGateActionDetailResponse from(HiveGateAction action) {
+        return HiveGateActionDetailResponse.builder()
+                .id(action.getId())
+                .title(action.getTitle())
+                .actionType(action.getActionType())
+                .actionTime(action.getActionTime())
+                .repeatEnabled(action.isRepeatEnabled())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/application/hive/dto/response/HiveGateActionListResponse.java
+++ b/src/main/java/kr/co/webee/application/hive/dto/response/HiveGateActionListResponse.java
@@ -1,0 +1,37 @@
+package kr.co.webee.application.hive.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+import kr.co.webee.domain.hive.type.GateActionType;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+@Schema(description = "개폐기 동작 목록 각 항목")
+public record HiveGateActionListResponse(
+        @Schema(description = "개폐기 동작 ID", example = "1")
+        Long id,
+
+        @Schema(description = "제목", example = "새벽 환기")
+        String title,
+
+        @Schema(description = "동작 유형", example = "OPEN_ONLY")
+        GateActionType actionType,
+
+        @Schema(description = "동작 시각", example = "09:00:00")
+        LocalTime actionTime,
+
+        @Schema(description = "반복 활성화 여부", example = "false")
+        boolean repeatEnabled
+) {
+    public static HiveGateActionListResponse from(HiveGateAction action) {
+        return HiveGateActionListResponse.builder()
+                .id(action.getId())
+                .title(action.getTitle())
+                .actionType(action.getActionType())
+                .actionTime(action.getActionTime())
+                .repeatEnabled(action.isRepeatEnabled())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/application/hive/dto/response/HiveGateActionRegisterResponse.java
+++ b/src/main/java/kr/co/webee/application/hive/dto/response/HiveGateActionRegisterResponse.java
@@ -1,0 +1,14 @@
+package kr.co.webee.application.hive.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+
+@Schema(description = "개폐기 동작 등록 response")
+public record HiveGateActionRegisterResponse(
+        @Schema(description = "개폐기 동작 ID", example = "1")
+        Long id
+) {
+    public static HiveGateActionRegisterResponse of(HiveGateAction hiveGateAction) {
+        return new HiveGateActionRegisterResponse(hiveGateAction.getId());
+    }
+}

--- a/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
+++ b/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
@@ -1,6 +1,7 @@
 package kr.co.webee.application.hive.service;
 
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.common.error.ErrorType;
 import kr.co.webee.common.error.exception.BusinessException;
@@ -11,6 +12,8 @@ import kr.co.webee.domain.hive.repository.HiveRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -27,5 +30,15 @@ public class HiveGateActionService {
         HiveGateAction hiveGateAction = hiveGateActionRepository.save(request.toEntity(hive));
 
         return HiveGateActionRegisterResponse.of(hiveGateAction);
+    }
+
+    @Transactional(readOnly = true)
+    public List<HiveGateActionListResponse> getAllHiveGateActionList(Long hiveId, Long userId) {
+        hiveRepository.findByIdAndUserId(hiveId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorType.HIVE_NOT_FOUND));
+
+        return hiveGateActionRepository.findAllByHiveId(hiveId).stream()
+                .map(HiveGateActionListResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
+++ b/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
@@ -1,0 +1,31 @@
+package kr.co.webee.application.hive.service;
+
+import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+import kr.co.webee.domain.hive.repository.HiveGateActionRepository;
+import kr.co.webee.domain.hive.repository.HiveRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class HiveGateActionService {
+
+    private final HiveGateActionRepository hiveGateActionRepository;
+    private final HiveRepository hiveRepository;
+
+    @Transactional
+    public HiveGateActionRegisterResponse registerHiveGateAction(Long hiveId, Long userId, HiveGateActionRegisterRequest request) {
+        Hive hive = hiveRepository.findByIdAndUserId(hiveId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorType.HIVE_NOT_FOUND));
+
+        HiveGateAction hiveGateAction = hiveGateActionRepository.save(request.toEntity(hive));
+
+        return HiveGateActionRegisterResponse.of(hiveGateAction);
+    }
+}

--- a/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
+++ b/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
@@ -1,6 +1,7 @@
 package kr.co.webee.application.hive.service;
 
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.request.HiveGateActionUpdateRequest;
 import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
@@ -50,6 +51,19 @@ public class HiveGateActionService {
 
         HiveGateAction hiveGateAction = hiveGateActionRepository.findByIdAndHiveId(actionId, hiveId)
                 .orElseThrow(() -> new BusinessException(ErrorType.HIVE_GATE_ACTION_NOT_FOUND));
+
+        return HiveGateActionDetailResponse.from(hiveGateAction);
+    }
+
+    @Transactional
+    public HiveGateActionDetailResponse updateHiveGateAction(Long hiveId, Long userId, Long actionId, HiveGateActionUpdateRequest request) {
+        hiveRepository.findByIdAndUserId(hiveId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorType.HIVE_NOT_FOUND));
+
+        HiveGateAction hiveGateAction = hiveGateActionRepository.findByIdAndHiveId(actionId, hiveId)
+                .orElseThrow(() -> new BusinessException(ErrorType.HIVE_GATE_ACTION_NOT_FOUND));
+
+        hiveGateAction.update(request.title(), request.actionType(), request.actionTime(), request.repeatEnabled());
 
         return HiveGateActionDetailResponse.from(hiveGateAction);
     }

--- a/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
+++ b/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
@@ -1,6 +1,7 @@
 package kr.co.webee.application.hive.service;
 
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.common.error.ErrorType;
@@ -40,5 +41,16 @@ public class HiveGateActionService {
         return hiveGateActionRepository.findAllByHiveId(hiveId).stream()
                 .map(HiveGateActionListResponse::from)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public HiveGateActionDetailResponse getHiveGateAction(Long hiveId, Long userId, Long actionId) {
+        hiveRepository.findByIdAndUserId(hiveId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorType.HIVE_NOT_FOUND));
+
+        HiveGateAction hiveGateAction = hiveGateActionRepository.findByIdAndHiveId(actionId, hiveId)
+                .orElseThrow(() -> new BusinessException(ErrorType.HIVE_GATE_ACTION_NOT_FOUND));
+
+        return HiveGateActionDetailResponse.from(hiveGateAction);
     }
 }

--- a/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
+++ b/src/main/java/kr/co/webee/application/hive/service/HiveGateActionService.java
@@ -67,4 +67,15 @@ public class HiveGateActionService {
 
         return HiveGateActionDetailResponse.from(hiveGateAction);
     }
+
+    @Transactional
+    public void deleteHiveGateAction(Long hiveId, Long userId, Long actionId) {
+        hiveRepository.findByIdAndUserId(hiveId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorType.HIVE_NOT_FOUND));
+
+        HiveGateAction hiveGateAction = hiveGateActionRepository.findByIdAndHiveId(actionId, hiveId)
+                .orElseThrow(() -> new BusinessException(ErrorType.HIVE_GATE_ACTION_NOT_FOUND));
+
+        hiveGateActionRepository.delete(hiveGateAction);
+    }
 }

--- a/src/main/java/kr/co/webee/common/error/ErrorType.java
+++ b/src/main/java/kr/co/webee/common/error/ErrorType.java
@@ -65,6 +65,7 @@ public enum ErrorType {
     HIVE_AUTO_CONTROL_BLOCKED_BY_SCHEDULE(CONFLICT, DEBUG, "HIVE_007", "자동제어 스케줄이 진행 중입니다"),
     HIVE_REPLACEMENT_HISTORY_NOT_FOUND(NOT_FOUND, DEBUG, "HIVE_008", "벌통 교체 기록을 찾을 수 없습니다"),
     HIVE_REPLACEMENT_HISTORY_INVALID_DATE(BAD_REQUEST, DEBUG, "HIVE_009", "교체 일자는 가장 최근 교체 일자 이후여야 합니다"),
+    HIVE_GATE_ACTION_NOT_FOUND(NOT_FOUND, DEBUG, "HIVE_010", "개폐기 동작을 찾을 수 없습니다"),
 
     // PostErrorType
     POST_NOT_FOUND(NOT_FOUND, DEBUG, "POST_001", "게시글을 찾을 수 없습니다"),

--- a/src/main/java/kr/co/webee/domain/hive/entity/HiveGateAction.java
+++ b/src/main/java/kr/co/webee/domain/hive/entity/HiveGateAction.java
@@ -58,4 +58,15 @@ public class HiveGateAction extends BaseTimeEntity {
         this.repeatEnabled = repeatEnabled;
         this.hive = Objects.requireNonNull(hive, "hive는 null이 될 수 없습니다.");
     }
+
+    public void update(String title, GateActionType actionType, LocalTime actionTime, boolean repeatEnabled) {
+        if (!StringUtils.hasText(title)) {
+            throw new IllegalArgumentException("title은 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+
+        this.title = title;
+        this.actionType = Objects.requireNonNull(actionType, "actionType은 null이 될 수 없습니다.");
+        this.actionTime = Objects.requireNonNull(actionTime, "actionTime은 null이 될 수 없습니다.");
+        this.repeatEnabled = repeatEnabled;
+    }
 }

--- a/src/main/java/kr/co/webee/domain/hive/entity/HiveGateAction.java
+++ b/src/main/java/kr/co/webee/domain/hive/entity/HiveGateAction.java
@@ -1,0 +1,61 @@
+package kr.co.webee.domain.hive.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.webee.domain.common.BaseTimeEntity;
+import kr.co.webee.domain.hive.type.GateActionType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class HiveGateAction extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GateActionType actionType;
+
+    @Column(nullable = false)
+    private LocalTime actionTime;
+
+    @Column(nullable = false)
+    private boolean repeatEnabled;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Hive hive;
+
+    @Builder
+    private HiveGateAction(Hive hive, String title, GateActionType actionType, LocalTime actionTime, boolean repeatEnabled) {
+        if (!StringUtils.hasText(title)) {
+            throw new IllegalArgumentException("title은 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+
+        this.title = title;
+        this.actionType = Objects.requireNonNull(actionType, "actionType은 null이 될 수 없습니다.");
+        this.actionTime = Objects.requireNonNull(actionTime, "actionTime은 null이 될 수 없습니다.");
+        this.repeatEnabled = repeatEnabled;
+        this.hive = Objects.requireNonNull(hive, "hive는 null이 될 수 없습니다.");
+    }
+}

--- a/src/main/java/kr/co/webee/domain/hive/repository/HiveGateActionRepository.java
+++ b/src/main/java/kr/co/webee/domain/hive/repository/HiveGateActionRepository.java
@@ -1,0 +1,14 @@
+package kr.co.webee.domain.hive.repository;
+
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HiveGateActionRepository extends JpaRepository<HiveGateAction, Long> {
+
+    List<HiveGateAction> findAllByHiveId(Long hiveId);
+
+    Optional<HiveGateAction> findByIdAndHiveId(Long id, Long hiveId);
+}

--- a/src/main/java/kr/co/webee/domain/hive/type/GateActionType.java
+++ b/src/main/java/kr/co/webee/domain/hive/type/GateActionType.java
@@ -1,0 +1,15 @@
+package kr.co.webee.domain.hive.type;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum GateActionType {
+    OPEN_ONLY("열기만"),
+    CLOSE_ONLY("닫기만"),
+    OPEN_CLOSE("여닫기");
+
+    private final String description;
+}

--- a/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
+++ b/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.request.HiveGateActionUpdateRequest;
 import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
@@ -93,5 +94,37 @@ public interface HiveGateActionApi {
             @PathVariable Long actionId,
 
             @Parameter(hidden = true) @UserId Long userId
+    );
+
+    @Operation(summary = "개폐기 동작 수정", description = "벌통에 등록된 개폐기 동작을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = HiveGateActionDetailResponse.class)
+                    )
+            ),
+    })
+    @ApiDocsErrorType({ErrorType.HIVE_NOT_FOUND, ErrorType.HIVE_GATE_ACTION_NOT_FOUND})
+    HiveGateActionDetailResponse updateHiveGateAction(
+            @Parameter(description = "벌통 ID", example = "1", required = true)
+            @PathVariable Long hiveId,
+
+            @Parameter(description = "개폐기 동작 ID", example = "1", required = true)
+            @PathVariable Long actionId,
+
+            @Parameter(hidden = true) @UserId Long userId,
+
+            @Parameter(
+                    description = "개폐기 동작 수정 요청 JSON",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = HiveGateActionUpdateRequest.class)
+                    )
+            )
+            @RequestBody @Valid HiveGateActionUpdateRequest request
     );
 }

--- a/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
+++ b/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
@@ -1,0 +1,51 @@
+package kr.co.webee.presentation.hive.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.presentation.support.annotation.ApiDocsErrorType;
+import kr.co.webee.presentation.support.annotation.UserId;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "개폐기 동작 API", description = "벌통 개폐기 동작 관련 API")
+public interface HiveGateActionApi {
+
+    @Operation(summary = "개폐기 동작 등록", description = "벌통 개폐기 동작을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "등록 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = HiveGateActionRegisterResponse.class)
+                    )
+            ),
+    })
+    @ApiDocsErrorType(ErrorType.HIVE_NOT_FOUND)
+    HiveGateActionRegisterResponse registerHiveGateAction(
+            @Parameter(description = "벌통 ID", example = "1", required = true)
+            @PathVariable Long hiveId,
+
+            @Parameter(hidden = true) @UserId Long userId,
+
+            @Parameter(
+                    description = "개폐기 동작 등록 요청 JSON",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = HiveGateActionRegisterRequest.class)
+                    )
+            )
+            @RequestBody @Valid HiveGateActionRegisterRequest request
+    );
+}

--- a/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
+++ b/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
@@ -2,6 +2,7 @@ package kr.co.webee.presentation.hive.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.common.error.ErrorType;
 import kr.co.webee.presentation.support.annotation.ApiDocsErrorType;
@@ -16,6 +18,8 @@ import kr.co.webee.presentation.support.annotation.UserId;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
 
 @Tag(name = "개폐기 동작 API", description = "벌통 개폐기 동작 관련 API")
 public interface HiveGateActionApi {
@@ -47,5 +51,24 @@ public interface HiveGateActionApi {
                     )
             )
             @RequestBody @Valid HiveGateActionRegisterRequest request
+    );
+
+    @Operation(summary = "개폐기 동작 목록 조회", description = "벌통에 등록된 개폐기 동작 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array = @ArraySchema(schema = @Schema(implementation = HiveGateActionListResponse.class))
+                    )
+            ),
+    })
+    @ApiDocsErrorType(ErrorType.HIVE_NOT_FOUND)
+    List<HiveGateActionListResponse> getAllHiveGateActionList(
+            @Parameter(description = "벌통 ID", example = "1", required = true)
+            @PathVariable Long hiveId,
+
+            @Parameter(hidden = true) @UserId Long userId
     );
 }

--- a/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
+++ b/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.common.error.ErrorType;
@@ -68,6 +69,28 @@ public interface HiveGateActionApi {
     List<HiveGateActionListResponse> getAllHiveGateActionList(
             @Parameter(description = "벌통 ID", example = "1", required = true)
             @PathVariable Long hiveId,
+
+            @Parameter(hidden = true) @UserId Long userId
+    );
+
+    @Operation(summary = "개폐기 동작 단건 조회", description = "벌통에 등록된 특정 개폐기 동작을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = HiveGateActionDetailResponse.class)
+                    )
+            ),
+    })
+    @ApiDocsErrorType({ErrorType.HIVE_NOT_FOUND, ErrorType.HIVE_GATE_ACTION_NOT_FOUND})
+    HiveGateActionDetailResponse getHiveGateAction(
+            @Parameter(description = "벌통 ID", example = "1", required = true)
+            @PathVariable Long hiveId,
+
+            @Parameter(description = "개폐기 동작 ID", example = "1", required = true)
+            @PathVariable Long actionId,
 
             @Parameter(hidden = true) @UserId Long userId
     );

--- a/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
+++ b/src/main/java/kr/co/webee/presentation/hive/api/HiveGateActionApi.java
@@ -127,4 +127,19 @@ public interface HiveGateActionApi {
             )
             @RequestBody @Valid HiveGateActionUpdateRequest request
     );
+
+    @Operation(summary = "개폐기 동작 삭제", description = "벌통에 등록된 개폐기 동작을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+    })
+    @ApiDocsErrorType({ErrorType.HIVE_NOT_FOUND, ErrorType.HIVE_GATE_ACTION_NOT_FOUND})
+    String deleteHiveGateAction(
+            @Parameter(description = "벌통 ID", example = "1", required = true)
+            @PathVariable Long hiveId,
+
+            @Parameter(description = "개폐기 동작 ID", example = "1", required = true)
+            @PathVariable Long actionId,
+
+            @Parameter(hidden = true) @UserId Long userId
+    );
 }

--- a/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
+++ b/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
@@ -2,16 +2,20 @@ package kr.co.webee.presentation.hive.controller;
 
 import jakarta.validation.Valid;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.application.hive.service.HiveGateActionService;
 import kr.co.webee.presentation.hive.api.HiveGateActionApi;
 import kr.co.webee.presentation.support.annotation.UserId;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequestMapping("/api/v1/hives")
 @RequiredArgsConstructor
@@ -28,5 +32,14 @@ public class HiveGateActionController implements HiveGateActionApi {
             @RequestBody @Valid HiveGateActionRegisterRequest request
     ) {
         return hiveGateActionService.registerHiveGateAction(hiveId, userId, request);
+    }
+
+    @Override
+    @GetMapping("/{hiveId}/gate/actions")
+    public List<HiveGateActionListResponse> getAllHiveGateActionList(
+            @PathVariable Long hiveId,
+            @UserId Long userId
+    ) {
+        return hiveGateActionService.getAllHiveGateActionList(hiveId, userId);
     }
 }

--- a/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
+++ b/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
@@ -1,0 +1,32 @@
+package kr.co.webee.presentation.hive.controller;
+
+import jakarta.validation.Valid;
+import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
+import kr.co.webee.application.hive.service.HiveGateActionService;
+import kr.co.webee.presentation.hive.api.HiveGateActionApi;
+import kr.co.webee.presentation.support.annotation.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/hives")
+@RequiredArgsConstructor
+@RestController
+public class HiveGateActionController implements HiveGateActionApi {
+
+    private final HiveGateActionService hiveGateActionService;
+
+    @Override
+    @PostMapping("/{hiveId}/gate/actions")
+    public HiveGateActionRegisterResponse registerHiveGateAction(
+            @PathVariable Long hiveId,
+            @UserId Long userId,
+            @RequestBody @Valid HiveGateActionRegisterRequest request
+    ) {
+        return hiveGateActionService.registerHiveGateAction(hiveId, userId, request);
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
+++ b/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
@@ -10,6 +10,7 @@ import kr.co.webee.application.hive.service.HiveGateActionService;
 import kr.co.webee.presentation.hive.api.HiveGateActionApi;
 import kr.co.webee.presentation.support.annotation.UserId;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -65,5 +66,16 @@ public class HiveGateActionController implements HiveGateActionApi {
             @RequestBody @Valid HiveGateActionUpdateRequest request
     ) {
         return hiveGateActionService.updateHiveGateAction(hiveId, userId, actionId, request);
+    }
+
+    @Override
+    @DeleteMapping("/{hiveId}/gate/actions/{actionId}")
+    public String deleteHiveGateAction(
+            @PathVariable Long hiveId,
+            @PathVariable Long actionId,
+            @UserId Long userId
+    ) {
+        hiveGateActionService.deleteHiveGateAction(hiveId, userId, actionId);
+        return "OK";
     }
 }

--- a/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
+++ b/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
@@ -2,6 +2,7 @@ package kr.co.webee.presentation.hive.controller;
 
 import jakarta.validation.Valid;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.request.HiveGateActionUpdateRequest;
 import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
@@ -10,6 +11,7 @@ import kr.co.webee.presentation.hive.api.HiveGateActionApi;
 import kr.co.webee.presentation.support.annotation.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -52,5 +54,16 @@ public class HiveGateActionController implements HiveGateActionApi {
             @UserId Long userId
     ) {
         return hiveGateActionService.getHiveGateAction(hiveId, userId, actionId);
+    }
+
+    @Override
+    @PatchMapping("/{hiveId}/gate/actions/{actionId}")
+    public HiveGateActionDetailResponse updateHiveGateAction(
+            @PathVariable Long hiveId,
+            @PathVariable Long actionId,
+            @UserId Long userId,
+            @RequestBody @Valid HiveGateActionUpdateRequest request
+    ) {
+        return hiveGateActionService.updateHiveGateAction(hiveId, userId, actionId, request);
     }
 }

--- a/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
+++ b/src/main/java/kr/co/webee/presentation/hive/controller/HiveGateActionController.java
@@ -2,6 +2,7 @@ package kr.co.webee.presentation.hive.controller;
 
 import jakarta.validation.Valid;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.application.hive.service.HiveGateActionService;
@@ -41,5 +42,15 @@ public class HiveGateActionController implements HiveGateActionApi {
             @UserId Long userId
     ) {
         return hiveGateActionService.getAllHiveGateActionList(hiveId, userId);
+    }
+
+    @Override
+    @GetMapping("/{hiveId}/gate/actions/{actionId}")
+    public HiveGateActionDetailResponse getHiveGateAction(
+            @PathVariable Long hiveId,
+            @PathVariable Long actionId,
+            @UserId Long userId
+    ) {
+        return hiveGateActionService.getHiveGateAction(hiveId, userId, actionId);
     }
 }

--- a/src/main/resources/db/migration/V2__create_hive_gate_action.sql
+++ b/src/main/resources/db/migration/V2__create_hive_gate_action.sql
@@ -5,7 +5,7 @@ CREATE TABLE hive_gate_action
     title          VARCHAR(255) NOT NULL,
     action_type    VARCHAR(20)  NOT NULL,
     action_time    TIME         NOT NULL,
-    repeat_enabled TINYINT(1)   NOT NULL DEFAULT 0,
+    repeat_enabled BOOLEAN      NOT NULL DEFAULT FALSE,
     created_at     DATETIME(6)  NOT NULL,
     modified_at    DATETIME(6),
     PRIMARY KEY (id),

--- a/src/main/resources/db/migration/V2__create_hive_gate_action.sql
+++ b/src/main/resources/db/migration/V2__create_hive_gate_action.sql
@@ -1,0 +1,13 @@
+CREATE TABLE hive_gate_action
+(
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    hive_id        BIGINT       NOT NULL,
+    title          VARCHAR(255) NOT NULL,
+    action_type    VARCHAR(20)  NOT NULL,
+    action_time    TIME         NOT NULL,
+    repeat_enabled TINYINT(1)   NOT NULL DEFAULT 0,
+    created_at     DATETIME(6)  NOT NULL,
+    modified_at    DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_hive_gate_action_hive FOREIGN KEY (hive_id) REFERENCES hive (id)
+);

--- a/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
@@ -335,4 +335,66 @@ class HiveGateActionServiceTest {
                     .isEqualTo(ErrorType.HIVE_NOT_FOUND);
         }
     }
+
+    @Nested
+    @DisplayName("개폐기 동작 삭제")
+    class DeleteHiveGateAction {
+
+        @Test
+        @DisplayName("개폐기 동작을 삭제한다.")
+        void deleteHiveGateAction() {
+            //given
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+
+            //when
+            hiveGateActionService.deleteHiveGateAction(hive.getId(), user.getId(), saved.getId());
+
+            //then
+            assertThat(hiveGateActionRepository.findById(saved.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 개폐기 동작을 삭제하려는 경우 예외가 발생한다.")
+        void deleteHiveGateActionNotFound() {
+            //given
+            Long notFoundActionId = -1L;
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.deleteHiveGateAction(hive.getId(), user.getId(), notFoundActionId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_GATE_ACTION_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통의 개폐기 동작을 삭제하려는 경우 예외가 발생한다.")
+        void deleteHiveGateActionWithNotFoundHive() {
+            //given
+            Long notFoundHiveId = -1L;
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.deleteHiveGateAction(notFoundHiveId, user.getId(), saved.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 벌통에 있는 개폐기 동작을 삭제하려는 경우 예외가 발생한다.")
+        void deleteHiveGateActionWithOtherUserHive() {
+            //given
+            User otherUser = userRepository.save(TestFixture.createUser("other-user"));
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.deleteHiveGateAction(hive.getId(), otherUser.getId(), saved.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+    }
 }

--- a/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.webee.application.hive.service;
 
 import kr.co.webee.annotation.IntegrationTest;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.common.error.ErrorType;
@@ -189,6 +190,71 @@ class HiveGateActionServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .extracting("type")
                     .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("개폐기 동작 단건 조회")
+    class GetHiveGateAction {
+
+        @Test
+        @DisplayName("개폐기 동작을 단건 조회한다.")
+        void getHiveGateAction() {
+            //given
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+
+            //when
+            HiveGateActionDetailResponse result = hiveGateActionService.getHiveGateAction(hive.getId(), user.getId(), saved.getId());
+
+            //then
+            assertThat(result.id()).isEqualTo(saved.getId());
+            assertThat(result.title()).isEqualTo("아침 열기");
+            assertThat(result.actionType()).isEqualTo(GateActionType.OPEN_ONLY);
+            assertThat(result.actionTime()).isEqualTo(LocalTime.of(8, 0));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 개폐기 동작을 조회하려는 경우 예외가 발생한다.")
+        void getHiveGateActionNotFound() {
+            //given
+            Long notFoundActionId = -1L;
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.getHiveGateAction(hive.getId(), user.getId(), notFoundActionId))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_GATE_ACTION_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통의 개폐기 동작을 조회하려는 경우 예외가 발생한다.")
+        void getHiveGateActionWithNotFoundHive() {
+            //given
+            Long notFoundHiveId = -1L;
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.getHiveGateAction(notFoundHiveId, user.getId(), saved.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 벌통의 개폐기 동작을 조회하려는 경우 예외가 발생한다.")
+        void getHiveGateActionFromOtherHive() {
+            //given
+            Hive otherHive = hiveRepository.save(TestFixture.createHive(null, user));
+            HiveGateAction action = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), otherHive));
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.getHiveGateAction(hive.getId(), user.getId(), action.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_GATE_ACTION_NOT_FOUND);
         }
     }
 }

--- a/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.webee.application.hive.service;
 
 import kr.co.webee.annotation.IntegrationTest;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.request.HiveGateActionUpdateRequest;
 import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
@@ -255,6 +256,83 @@ class HiveGateActionServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .extracting("type")
                     .isEqualTo(ErrorType.HIVE_GATE_ACTION_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("개폐기 동작 수정")
+    class UpdateHiveGateAction {
+
+        @Test
+        @DisplayName("개폐기 동작을 수정한다.")
+        void updateHiveGateAction() {
+            //given
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+            HiveGateActionUpdateRequest request = new HiveGateActionUpdateRequest(
+                    "저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), true
+            );
+
+            //when
+            HiveGateActionDetailResponse result = hiveGateActionService.updateHiveGateAction(hive.getId(), user.getId(), saved.getId(), request);
+
+            //then
+            assertThat(result.title()).isEqualTo("저녁 닫기");
+            assertThat(result.actionType()).isEqualTo(GateActionType.CLOSE_ONLY);
+            assertThat(result.actionTime()).isEqualTo(LocalTime.of(20, 0));
+            assertThat(result.repeatEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 개폐기 동작을 수정하려는 경우 예외가 발생한다.")
+        void updateHiveGateActionNotFound() {
+            //given
+            Long notFoundActionId = -1L;
+            HiveGateActionUpdateRequest request = new HiveGateActionUpdateRequest(
+                    "저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), false
+            );
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.updateHiveGateAction(hive.getId(), user.getId(), notFoundActionId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_GATE_ACTION_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통의 개폐기 동작을 수정하려는 경우 예외가 발생한다.")
+        void updateHiveGateActionWithNotFoundHive() {
+            //given
+            Long notFoundHiveId = -1L;
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+            HiveGateActionUpdateRequest request = new HiveGateActionUpdateRequest(
+                    "저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), false
+            );
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.updateHiveGateAction(notFoundHiveId, user.getId(), saved.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 벌통에 있는 개폐기 동작을 수정하려는 경우 예외가 발생한다.")
+        void updateHiveGateActionWithOtherUserHive() {
+            //given
+            User otherUser = userRepository.save(TestFixture.createUser("other-user"));
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+            HiveGateActionUpdateRequest request = new HiveGateActionUpdateRequest(
+                    "저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), false
+            );
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.updateHiveGateAction(hive.getId(), otherUser.getId(), saved.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
         }
     }
 }

--- a/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.webee.application.hive.service;
 
 import kr.co.webee.annotation.IntegrationTest;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.common.error.ErrorType;
 import kr.co.webee.common.error.exception.BusinessException;
@@ -144,6 +145,50 @@ class HiveGateActionServiceTest {
 
             //then
             assertThat(actions).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("개폐기 동작 목록 조회")
+    class GetAllHiveGateActionList {
+
+        @Test
+        @DisplayName("벌통의 개폐기 동작 목록을 조회한다.")
+        void getAllHiveGateActionList() {
+            //given
+            hiveGateActionRepository.save(TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+            hiveGateActionRepository.save(TestFixture.createHiveGateAction("저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), hive));
+
+            //when
+            List<HiveGateActionListResponse> result = hiveGateActionService.getAllHiveGateActionList(hive.getId(), user.getId());
+
+            //then
+            assertThat(result).hasSize(2)
+                    .extracting("title")
+                    .containsExactlyInAnyOrder("아침 열기", "저녁 닫기");
+        }
+
+        @Test
+        @DisplayName("등록된 개폐기 동작이 없으면 빈 목록을 반환한다.")
+        void getAllHiveGateActionListEmpty() {
+            //when
+            List<HiveGateActionListResponse> result = hiveGateActionService.getAllHiveGateActionList(hive.getId(), user.getId());
+
+            //then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통의 개폐기 동작 목록을 조회하려는 경우 예외가 발생한다.")
+        void getAllHiveGateActionListWithNotFoundHive() {
+            //given
+            Long notFoundHiveId = -1L;
+
+            //when - then
+            assertThatThrownBy(() -> hiveGateActionService.getAllHiveGateActionList(notFoundHiveId, user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
         }
     }
 }

--- a/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
@@ -1,0 +1,149 @@
+package kr.co.webee.application.hive.service;
+
+import kr.co.webee.annotation.IntegrationTest;
+import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+import kr.co.webee.domain.hive.repository.HiveGateActionRepository;
+import kr.co.webee.domain.hive.repository.HiveRepository;
+import kr.co.webee.domain.hive.type.GateActionType;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class HiveGateActionServiceTest {
+
+    @Autowired
+    private HiveGateActionService hiveGateActionService;
+
+    @Autowired
+    private HiveGateActionRepository hiveGateActionRepository;
+
+    @Autowired
+    private HiveRepository hiveRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+    private Hive hive;
+
+    @BeforeEach
+    void setUp() {
+        hiveGateActionRepository.deleteAll();
+        hiveRepository.deleteAll();
+        userRepository.deleteAll();
+
+        user = userRepository.save(TestFixture.createUser("gate-user"));
+        hive = hiveRepository.save(TestFixture.createHive(null, user));
+    }
+
+    @Nested
+    @DisplayName("개폐기 동작 등록")
+    class RegisterHiveGateAction {
+
+        @Test
+        @DisplayName("개폐기 동작을 등록한다.")
+        void registerHiveGateAction() {
+            //given
+            HiveGateActionRegisterRequest request = new HiveGateActionRegisterRequest(
+                    "새벽 환기", GateActionType.OPEN_ONLY, LocalTime.of(9, 0), false
+            );
+
+            //when
+            HiveGateActionRegisterResponse response =
+                    hiveGateActionService.registerHiveGateAction(hive.getId(), user.getId(), request);
+
+            //then
+            assertThat(response.id()).isNotNull();
+
+            HiveGateAction saved = hiveGateActionRepository.findById(response.id()).orElseThrow();
+            assertThat(saved.getTitle()).isEqualTo("새벽 환기");
+            assertThat(saved.getActionType()).isEqualTo(GateActionType.OPEN_ONLY);
+            assertThat(saved.getActionTime()).isEqualTo(LocalTime.of(9, 0));
+            assertThat(saved.isRepeatEnabled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("반복 활성화 상태로 개폐기 동작을 등록한다.")
+        void registerHiveGateActionWithRepeat() {
+            //given
+            HiveGateActionRegisterRequest request = new HiveGateActionRegisterRequest(
+                    "매일 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), true
+            );
+
+            //when
+            HiveGateActionRegisterResponse response =
+                    hiveGateActionService.registerHiveGateAction(hive.getId(), user.getId(), request);
+
+            //then
+            HiveGateAction saved = hiveGateActionRepository.findById(response.id()).orElseThrow();
+            assertThat(saved.isRepeatEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통에 개폐기 동작을 등록하려는 경우 예외가 발생한다.")
+        void registerWithNotFoundHive() {
+            //given
+            Long notFoundHiveId = -1L;
+            HiveGateActionRegisterRequest request = new HiveGateActionRegisterRequest(
+                    "새벽 환기", GateActionType.OPEN_ONLY, LocalTime.of(9, 0), false
+            );
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveGateActionService.registerHiveGateAction(notFoundHiveId, user.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 벌통에 개폐기 동작을 등록하려는 경우 예외가 발생한다.")
+        void registerWithOtherUserHive() {
+            //given
+            User otherUser = userRepository.save(TestFixture.createUser("other-user"));
+            HiveGateActionRegisterRequest request = new HiveGateActionRegisterRequest(
+                    "새벽 환기", GateActionType.OPEN_ONLY, LocalTime.of(9, 0), false
+            );
+
+            //when - then
+            assertThatThrownBy(() ->
+                    hiveGateActionService.registerHiveGateAction(hive.getId(), otherUser.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("하나의 벌통에 여러 개폐기 동작을 등록할 수 있다.")
+        void registerMultipleGateActions() {
+            //given
+            hiveGateActionService.registerHiveGateAction(hive.getId(), user.getId(),
+                    new HiveGateActionRegisterRequest("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), true));
+            hiveGateActionService.registerHiveGateAction(hive.getId(), user.getId(),
+                    new HiveGateActionRegisterRequest("저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), true));
+
+            //when
+            List<HiveGateAction> actions = hiveGateActionRepository.findAllByHiveId(hive.getId());
+
+            //then
+            assertThat(actions).hasSize(2);
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/domain/hive/entity/HiveGateActionTest.java
+++ b/src/test/java/kr/co/webee/domain/hive/entity/HiveGateActionTest.java
@@ -1,0 +1,73 @@
+package kr.co.webee.domain.hive.entity;
+
+import kr.co.webee.domain.hive.type.GateActionType;
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HiveGateActionTest {
+
+    @Nested
+    @DisplayName("개폐기 동작 생성")
+    class Create {
+
+        @Test
+        @DisplayName("정상적인 값으로 개폐기 동작을 생성한다.")
+        void createHiveGateAction() {
+            //given
+            Hive hive = TestFixture.createHive(null, TestFixture.createUser(null));
+
+            //when
+            HiveGateAction action = HiveGateAction.builder()
+                    .hive(hive)
+                    .title("새벽 환기")
+                    .actionType(GateActionType.OPEN_ONLY)
+                    .actionTime(LocalTime.of(9, 0))
+                    .repeatEnabled(true)
+                    .build();
+
+            //then
+            assertThat(action.getTitle()).isEqualTo("새벽 환기");
+            assertThat(action.getActionType()).isEqualTo(GateActionType.OPEN_ONLY);
+            assertThat(action.getActionTime()).isEqualTo(LocalTime.of(9, 0));
+            assertThat(action.isRepeatEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("제목이 빈 문자열인 경우 예외가 발생한다.")
+        void createWithBlankTitle() {
+            //given
+            Hive hive = TestFixture.createHive(null, TestFixture.createUser(null));
+
+            //when - then
+            assertThatThrownBy(() -> HiveGateAction.builder()
+                    .hive(hive)
+                    .title("")
+                    .actionType(GateActionType.OPEN_ONLY)
+                    .actionTime(LocalTime.of(9, 0))
+                    .repeatEnabled(false)
+                    .build())
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("hive가 null인 경우 예외가 발생한다.")
+        void createWithNullHive() {
+            //when - then
+            assertThatThrownBy(() -> HiveGateAction.builder()
+                    .hive(null)
+                    .title("새벽 환기")
+                    .actionType(GateActionType.OPEN_ONLY)
+                    .actionTime(LocalTime.of(9, 0))
+                    .repeatEnabled(false)
+                    .build())
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/domain/hive/repository/HiveGateActionRepositoryTest.java
+++ b/src/test/java/kr/co/webee/domain/hive/repository/HiveGateActionRepositoryTest.java
@@ -1,0 +1,102 @@
+package kr.co.webee.domain.hive.repository;
+
+import kr.co.webee.domain.annotation.RepositoryTest;
+import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+import kr.co.webee.domain.hive.type.GateActionType;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+class HiveGateActionRepositoryTest {
+
+    @Autowired
+    private HiveGateActionRepository hiveGateActionRepository;
+
+    @Autowired
+    private HiveRepository hiveRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Hive hive;
+
+    @BeforeEach
+    void setUp() {
+        User user = userRepository.save(TestFixture.createUser("gate-repo-user"));
+        hive = hiveRepository.save(TestFixture.createHive(null, user));
+    }
+
+    @Nested
+    @DisplayName("hiveId로 개폐기 동작 목록 조회")
+    class FindAllByHiveId {
+
+        @Test
+        @DisplayName("벌통 ID에 해당하는 개폐기 동작 목록을 조회한다.")
+        void findAllByHiveId() {
+            //given
+            hiveGateActionRepository.save(TestFixture.createHiveGateAction("아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), hive));
+            hiveGateActionRepository.save(TestFixture.createHiveGateAction("저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), hive));
+
+            //when
+            List<HiveGateAction> result = hiveGateActionRepository.findAllByHiveId(hive.getId());
+
+            //then
+            assertThat(result).hasSize(2)
+                    .extracting("title")
+                    .containsExactlyInAnyOrder("아침 열기", "저녁 닫기");
+        }
+
+        @Test
+        @DisplayName("등록된 개폐기 동작이 없는 경우 빈 목록을 반환한다.")
+        void findAllByHiveIdEmpty() {
+            //when
+            List<HiveGateAction> result = hiveGateActionRepository.findAllByHiveId(hive.getId());
+
+            //then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("id와 hiveId로 개폐기 동작 단건 조회")
+    class FindByIdAndHiveId {
+
+        @Test
+        @DisplayName("id와 hiveId가 일치하는 개폐기 동작을 조회한다.")
+        void findByIdAndHiveId() {
+            //given
+            HiveGateAction saved = hiveGateActionRepository.save(
+                    TestFixture.createHiveGateAction("새벽 환기", GateActionType.OPEN_CLOSE, LocalTime.of(6, 0), hive));
+
+            //when
+            Optional<HiveGateAction> result = hiveGateActionRepository.findByIdAndHiveId(saved.getId(), hive.getId());
+
+            //then
+            assertThat(result).isPresent();
+            assertThat(result.get().getTitle()).isEqualTo("새벽 환기");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 id로 조회하면 빈 Optional을 반환한다.")
+        void findByIdAndHiveIdNotFound() {
+            //when
+            Optional<HiveGateAction> result = hiveGateActionRepository.findByIdAndHiveId(-1L, hive.getId());
+
+            //then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
@@ -2,6 +2,7 @@ package kr.co.webee.presentation.hive.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.application.hive.service.HiveGateActionService;
@@ -169,6 +170,29 @@ class HiveGateActionControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data").isArray())
                     .andExpect(jsonPath("$.data.length()").value(0))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("개폐기 동작 단건 조회")
+    class GetHiveGateAction {
+
+        @Test
+        @DisplayName("개폐기 동작을 단건 조회한다.")
+        void getHiveGateAction() throws Exception {
+            //given
+            HiveGateActionDetailResponse response = new HiveGateActionDetailResponse(
+                    1L, "아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), true
+            );
+            when(hiveGateActionService.getHiveGateAction(anyLong(), anyLong(), anyLong())).thenReturn(response);
+
+            //when - then
+            mockMvc.perform(get("/api/v1/hives/{hiveId}/gate/actions/{actionId}", 1L, 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.title").value("아침 열기"))
                     .andDo(print());
         }
     }

--- a/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
@@ -2,6 +2,7 @@ package kr.co.webee.presentation.hive.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.request.HiveGateActionUpdateRequest;
 import kr.co.webee.application.hive.dto.response.HiveGateActionDetailResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
@@ -33,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -193,6 +195,51 @@ class HiveGateActionControllerTest {
                     .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
                     .andExpect(jsonPath("$.data.id").value(1L))
                     .andExpect(jsonPath("$.data.title").value("아침 열기"))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("개폐기 동작 수정")
+    class UpdateHiveGateAction {
+
+        @Test
+        @DisplayName("개폐기 동작을 수정한다.")
+        void updateHiveGateAction() throws Exception {
+            //given
+            HiveGateActionUpdateRequest request = new HiveGateActionUpdateRequest(
+                    "저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), true
+            );
+            HiveGateActionDetailResponse response = new HiveGateActionDetailResponse(
+                    1L, "저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), true
+            );
+            when(hiveGateActionService.updateHiveGateAction(anyLong(), anyLong(), anyLong(), any())).thenReturn(response);
+
+            //when - then
+            mockMvc.perform(patch("/api/v1/hives/{hiveId}/gate/actions/{actionId}", 1L, 1L)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data.title").value("저녁 닫기"))
+                    .andExpect(jsonPath("$.data.actionType").value("CLOSE_ONLY"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("제목 없이 개폐기 동작을 수정하려는 경우 400을 반환한다.")
+        void updateWithBlankTitle() throws Exception {
+            //given
+            HiveGateActionUpdateRequest request = new HiveGateActionUpdateRequest(
+                    "", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), false
+            );
+
+            //when - then
+            mockMvc.perform(patch("/api/v1/hives/{hiveId}/gate/actions/{actionId}", 1L, 1L)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(ErrorType.FAILED_VALIDATION.getCode()))
                     .andDo(print());
         }
     }

--- a/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
@@ -1,0 +1,134 @@
+package kr.co.webee.presentation.hive.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
+import kr.co.webee.application.hive.service.HiveGateActionService;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.config.TestWebConfig;
+import kr.co.webee.domain.hive.type.GateActionType;
+import kr.co.webee.presentation.config.WebConfig;
+import kr.co.webee.presentation.support.resolver.UserIdArgumentResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.time.LocalTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestWebConfig.class)
+@WebMvcTest(
+        controllers = HiveGateActionController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OncePerRequestFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UserIdArgumentResolver.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)
+        }
+)
+@ActiveProfiles("test")
+class HiveGateActionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private HiveGateActionService hiveGateActionService;
+
+    @Nested
+    @DisplayName("개폐기 동작 등록")
+    class RegisterHiveGateAction {
+
+        @Test
+        @DisplayName("개폐기 동작을 등록한다.")
+        void registerHiveGateAction() throws Exception {
+            //given
+            HiveGateActionRegisterRequest request = new HiveGateActionRegisterRequest(
+                    "새벽 환기", GateActionType.OPEN_ONLY, LocalTime.of(9, 0), false
+            );
+            when(hiveGateActionService.registerHiveGateAction(anyLong(), anyLong(), any()))
+                    .thenReturn(new HiveGateActionRegisterResponse(1L));
+
+            //when - then
+            mockMvc.perform(post("/api/v1/hives/{hiveId}/gate/actions", 1L)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("제목 없이 개폐기 동작을 등록하려는 경우 400을 반환한다.")
+        void registerWithBlankTitle() throws Exception {
+            //given
+            HiveGateActionRegisterRequest request = new HiveGateActionRegisterRequest(
+                    "", GateActionType.OPEN_ONLY, LocalTime.of(9, 0), false
+            );
+
+            //when - then
+            mockMvc.perform(post("/api/v1/hives/{hiveId}/gate/actions", 1L)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(ErrorType.FAILED_VALIDATION.getCode()))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("동작 유형 없이 개폐기 동작을 등록하려는 경우 400을 반환한다.")
+        void registerWithNullActionType() throws Exception {
+            //given
+            HiveGateActionRegisterRequest request = new HiveGateActionRegisterRequest(
+                    "새벽 환기", null, LocalTime.of(9, 0), false
+            );
+
+            //when - then
+            mockMvc.perform(post("/api/v1/hives/{hiveId}/gate/actions", 1L)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(ErrorType.FAILED_VALIDATION.getCode()))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("동작 시각 없이 개폐기 동작을 등록하려는 경우 400을 반환한다.")
+        void registerWithNullActionTime() throws Exception {
+            //given
+            HiveGateActionRegisterRequest request = new HiveGateActionRegisterRequest(
+                    "새벽 환기", GateActionType.OPEN_ONLY, null, false
+            );
+
+            //when - then
+            mockMvc.perform(post("/api/v1/hives/{hiveId}/gate/actions", 1L)
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(ErrorType.FAILED_VALIDATION.getCode()))
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
@@ -2,6 +2,7 @@ package kr.co.webee.presentation.hive.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.webee.application.hive.dto.request.HiveGateActionRegisterRequest;
+import kr.co.webee.application.hive.dto.response.HiveGateActionListResponse;
 import kr.co.webee.application.hive.dto.response.HiveGateActionRegisterResponse;
 import kr.co.webee.application.hive.service.HiveGateActionService;
 import kr.co.webee.common.error.ErrorType;
@@ -25,10 +26,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.time.LocalTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -128,6 +131,44 @@ class HiveGateActionControllerTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(ErrorType.FAILED_VALIDATION.getCode()))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("개폐기 동작 목록 조회")
+    class GetAllHiveGateActionList {
+
+        @Test
+        @DisplayName("개폐기 동작 목록을 조회한다.")
+        void getAllHiveGateActionList() throws Exception {
+            //given
+            List<HiveGateActionListResponse> response = List.of(
+                    new HiveGateActionListResponse(1L, "아침 열기", GateActionType.OPEN_ONLY, LocalTime.of(8, 0), true),
+                    new HiveGateActionListResponse(2L, "저녁 닫기", GateActionType.CLOSE_ONLY, LocalTime.of(20, 0), false)
+            );
+            when(hiveGateActionService.getAllHiveGateActionList(anyLong(), anyLong())).thenReturn(response);
+
+            //when - then
+            mockMvc.perform(get("/api/v1/hives/{hiveId}/gate/actions", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("등록된 개폐기 동작이 없으면 빈 배열을 반환한다.")
+        void getAllHiveGateActionListEmpty() throws Exception {
+            //given
+            when(hiveGateActionService.getAllHiveGateActionList(anyLong(), anyLong())).thenReturn(List.of());
+
+            //when - then
+            mockMvc.perform(get("/api/v1/hives/{hiveId}/gate/actions", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data.length()").value(0))
                     .andDo(print());
         }
     }

--- a/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/hive/controller/HiveGateActionControllerTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -240,6 +241,22 @@ class HiveGateActionControllerTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(ErrorType.FAILED_VALIDATION.getCode()))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("개폐기 동작 삭제")
+    class DeleteHiveGateAction {
+
+        @Test
+        @DisplayName("개폐기 동작을 삭제한다.")
+        void deleteHiveGateAction() throws Exception {
+            //when - then
+            mockMvc.perform(delete("/api/v1/hives/{hiveId}/gate/actions/{actionId}", 1L, 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data").value("OK"))
                     .andDo(print());
         }
     }

--- a/src/test/java/kr/co/webee/support/util/TestFixture.java
+++ b/src/test/java/kr/co/webee/support/util/TestFixture.java
@@ -1,0 +1,40 @@
+package kr.co.webee.support.util;
+
+import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.entity.HiveGateAction;
+import kr.co.webee.domain.hive.type.GateActionType;
+import kr.co.webee.domain.user.entity.User;
+
+import java.time.LocalTime;
+
+public class TestFixture {
+
+    public static User createUser(String username) {
+        return User.builder()
+                .username(username != null ? username : "test-user")
+                .password("password")
+                .name("테스트유저")
+                .businessRegistered(false)
+                .build();
+    }
+
+    public static Hive createHive(String macAddress, User user) {
+        return Hive.builder()
+                .macAddress(macAddress != null ? macAddress : "AA:BB:CC:DD:EE:FF")
+                .name("테스트 벌통")
+                .region("서울")
+                .location("강남구")
+                .user(user)
+                .build();
+    }
+
+    public static HiveGateAction createHiveGateAction(String title, GateActionType actionType, LocalTime actionTime, Hive hive) {
+        return HiveGateAction.builder()
+                .hive(hive)
+                .title(title != null ? title : "테스트 개폐기 동작")
+                .actionType(actionType != null ? actionType : GateActionType.OPEN_ONLY)
+                .actionTime(actionTime != null ? actionTime : LocalTime.of(9, 0))
+                .repeatEnabled(false)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧷 이슈

- close #173

## 🔨 작업 내용

- 벌통 개폐기 동작 도메인 구성
  - `HiveGateAction` 엔티티 및 `GateActionType` enum 추가 (778b6cc)
  - `hive_gate_action` 테이블 Flyway 마이그레이션 스크립트 작성 (56cecc9)
- 개폐기 동작 CRUD API 구현
  - 개폐기 동작 등록 API (0ea75dd)
  - 개폐기 동작 목록 조회 API (0d1ffb1)
  - 개폐기 동작 상세 조회 API (9767bba)
  - 개폐기 동작 수정 API (e95566b)
  - 개폐기 동작 삭제 API (abe9f7f)
- 테스트 환경 개선
  - 엔티티 생성 로직을 중앙화한 `TestFixture` 유틸 추가 (d5db83f)