### PR TITLE
fix: Hive 삭제 시 FK 제약 오류 수정

### DIFF
--- a/src/main/java/kr/co/webee/application/hive/service/HiveService.java
+++ b/src/main/java/kr/co/webee/application/hive/service/HiveService.java
@@ -3,7 +3,13 @@ package kr.co.webee.application.hive.service;
 import kr.co.webee.common.error.ErrorType;
 import kr.co.webee.common.error.exception.BusinessException;
 import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.repository.HiveBeeCountRepository;
+import kr.co.webee.domain.hive.repository.HiveControlRepository;
+import kr.co.webee.domain.hive.repository.HiveControlScheduleRepository;
+import kr.co.webee.domain.hive.repository.HiveGateActionRepository;
 import kr.co.webee.domain.hive.repository.HiveRepository;
+import kr.co.webee.domain.hive.repository.HiveReplacementHistoryRepository;
+import kr.co.webee.domain.hive.repository.HiveTelemetryRepository;
 import kr.co.webee.domain.user.entity.User;
 import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.presentation.hive.dto.request.HiveRegisterRequest;
@@ -22,6 +28,12 @@ import java.util.List;
 public class HiveService {
     private final HiveRepository hiveRepository;
     private final UserRepository userRepository;
+    private final HiveTelemetryRepository hiveTelemetryRepository;
+    private final HiveBeeCountRepository hiveBeeCountRepository;
+    private final HiveControlRepository hiveControlRepository;
+    private final HiveControlScheduleRepository hiveControlScheduleRepository;
+    private final HiveGateActionRepository hiveGateActionRepository;
+    private final HiveReplacementHistoryRepository hiveReplacementHistoryRepository;
 
     @Transactional
     public HiveRegisterResponse registerHive(HiveRegisterRequest request, Long userId) {
@@ -64,6 +76,12 @@ public class HiveService {
         Hive hive = hiveRepository.findByIdAndUserId(hiveId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorType.HIVE_NOT_FOUND));
 
+        hiveTelemetryRepository.deleteAllByHiveId(hiveId);
+        hiveBeeCountRepository.deleteAllByHiveId(hiveId);
+        hiveControlRepository.deleteAllByHiveId(hiveId);
+        hiveControlScheduleRepository.deleteAllByHiveId(hiveId);
+        hiveGateActionRepository.deleteAllByHiveId(hiveId);
+        hiveReplacementHistoryRepository.deleteAllByHiveId(hiveId);
         hiveRepository.delete(hive);
     }
 }

--- a/src/main/java/kr/co/webee/domain/hive/repository/HiveBeeCountRepository.java
+++ b/src/main/java/kr/co/webee/domain/hive/repository/HiveBeeCountRepository.java
@@ -2,6 +2,9 @@ package kr.co.webee.domain.hive.repository;
 
 import kr.co.webee.domain.hive.entity.HiveBeeCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -11,4 +14,8 @@ import java.util.List;
 public interface HiveBeeCountRepository extends JpaRepository<HiveBeeCount, Long> {
 
     List<HiveBeeCount> findByHiveIdAndRecordedAtBetween(Long hiveId, LocalDateTime start, LocalDateTime end);
+
+    @Modifying
+    @Query("DELETE FROM HiveBeeCount b WHERE b.hive.id = :hiveId")
+    void deleteAllByHiveId(@Param("hiveId") Long hiveId);
 }

--- a/src/main/java/kr/co/webee/domain/hive/repository/HiveControlRepository.java
+++ b/src/main/java/kr/co/webee/domain/hive/repository/HiveControlRepository.java
@@ -3,6 +3,9 @@ package kr.co.webee.domain.hive.repository;
 import kr.co.webee.domain.hive.entity.HiveControl;
 import kr.co.webee.domain.hive.type.ControlType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,4 +16,8 @@ public interface HiveControlRepository extends JpaRepository<HiveControl, Long> 
     Optional<HiveControl> findByHiveIdAndType(Long hiveId, ControlType type);
 
     List<HiveControl> findAllByHiveId(Long hiveId);
+
+    @Modifying
+    @Query("DELETE FROM HiveControl c WHERE c.hive.id = :hiveId")
+    void deleteAllByHiveId(@Param("hiveId") Long hiveId);
 }

--- a/src/main/java/kr/co/webee/domain/hive/repository/HiveControlScheduleRepository.java
+++ b/src/main/java/kr/co/webee/domain/hive/repository/HiveControlScheduleRepository.java
@@ -2,10 +2,10 @@ package kr.co.webee.domain.hive.repository;
 
 import kr.co.webee.domain.hive.entity.HiveControlSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -29,4 +29,8 @@ public interface HiveControlScheduleRepository extends JpaRepository<HiveControl
               AND s.endTime > :now
             """)
     boolean existsActiveSchedule(@Param("hiveId") Long hiveId, @Param("now") LocalTime now);
+
+    @Modifying
+    @Query("DELETE FROM HiveControlSchedule s WHERE s.hive.id = :hiveId")
+    void deleteAllByHiveId(@Param("hiveId") Long hiveId);
 }

--- a/src/main/java/kr/co/webee/domain/hive/repository/HiveGateActionRepository.java
+++ b/src/main/java/kr/co/webee/domain/hive/repository/HiveGateActionRepository.java
@@ -2,6 +2,9 @@ package kr.co.webee.domain.hive.repository;
 
 import kr.co.webee.domain.hive.entity.HiveGateAction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +14,8 @@ public interface HiveGateActionRepository extends JpaRepository<HiveGateAction, 
     List<HiveGateAction> findAllByHiveId(Long hiveId);
 
     Optional<HiveGateAction> findByIdAndHiveId(Long id, Long hiveId);
+
+    @Modifying
+    @Query("DELETE FROM HiveGateAction a WHERE a.hive.id = :hiveId")
+    void deleteAllByHiveId(@Param("hiveId") Long hiveId);
 }

--- a/src/main/java/kr/co/webee/domain/hive/repository/HiveReplacementHistoryRepository.java
+++ b/src/main/java/kr/co/webee/domain/hive/repository/HiveReplacementHistoryRepository.java
@@ -4,8 +4,9 @@ import kr.co.webee.domain.hive.entity.HiveReplacementHistory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -39,4 +40,8 @@ public interface HiveReplacementHistoryRepository extends JpaRepository<HiveRepl
             LIMIT 1
             """)
     Optional<HiveReplacementHistory> findOlderByHiveId(Long hiveId, LocalDate replacedAt);
+
+    @Modifying
+    @Query("DELETE FROM HiveReplacementHistory h WHERE h.hive.id = :hiveId")
+    void deleteAllByHiveId(@Param("hiveId") Long hiveId);
 }

--- a/src/main/java/kr/co/webee/domain/hive/repository/HiveTelemetryRepository.java
+++ b/src/main/java/kr/co/webee/domain/hive/repository/HiveTelemetryRepository.java
@@ -2,6 +2,9 @@ package kr.co.webee.domain.hive.repository;
 
 import kr.co.webee.domain.hive.entity.HiveTelemetry;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -11,4 +14,8 @@ import java.util.List;
 public interface HiveTelemetryRepository extends JpaRepository<HiveTelemetry, Long> {
 
     List<HiveTelemetry> findByHiveIdAndRecordedAtBetween(Long hiveId, LocalDateTime start, LocalDateTime end);
+
+    @Modifying
+    @Query("DELETE FROM HiveTelemetry t WHERE t.hive.id = :hiveId")
+    void deleteAllByHiveId(@Param("hiveId") Long hiveId);
 }

--- a/src/test/java/kr/co/webee/application/auth/service/AuthServiceTest.java
+++ b/src/test/java/kr/co/webee/application/auth/service/AuthServiceTest.java
@@ -33,7 +33,7 @@ class AuthServiceTest {
 
     @BeforeEach
     void cleanUp() {
-        userRepository.deleteAll();
+        userRepository.deleteAllInBatch();
     }
 
     @Nested

--- a/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveGateActionServiceTest.java
@@ -48,9 +48,9 @@ class HiveGateActionServiceTest {
 
     @BeforeEach
     void setUp() {
-        hiveGateActionRepository.deleteAll();
-        hiveRepository.deleteAll();
-        userRepository.deleteAll();
+        hiveGateActionRepository.deleteAllInBatch();
+        hiveRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
 
         user = userRepository.save(TestFixture.createUser("gate-user"));
         hive = hiveRepository.save(TestFixture.createHive(null, user));

--- a/src/test/java/kr/co/webee/application/hive/service/HiveReplacementHistoryServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveReplacementHistoryServiceTest.java
@@ -46,9 +46,9 @@ class HiveReplacementHistoryServiceTest {
 
     @BeforeEach
     void setUp() {
-        hiveReplacementHistoryRepository.deleteAll();
-        hiveRepository.deleteAll();
-        userRepository.deleteAll();
+        hiveReplacementHistoryRepository.deleteAllInBatch();
+        hiveRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
 
         user = userRepository.save(
                 User.builder()

--- a/src/test/java/kr/co/webee/application/hive/service/HiveServiceTest.java
+++ b/src/test/java/kr/co/webee/application/hive/service/HiveServiceTest.java
@@ -1,0 +1,281 @@
+package kr.co.webee.application.hive.service;
+
+import kr.co.webee.annotation.IntegrationTest;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.repository.HiveBeeCountRepository;
+import kr.co.webee.domain.hive.repository.HiveControlRepository;
+import kr.co.webee.domain.hive.repository.HiveControlScheduleRepository;
+import kr.co.webee.domain.hive.repository.HiveGateActionRepository;
+import kr.co.webee.domain.hive.repository.HiveRepository;
+import kr.co.webee.domain.hive.repository.HiveReplacementHistoryRepository;
+import kr.co.webee.domain.hive.repository.HiveTelemetryRepository;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
+import kr.co.webee.presentation.hive.dto.request.HiveRegisterRequest;
+import kr.co.webee.presentation.hive.dto.request.HiveUpdateRequest;
+import kr.co.webee.presentation.hive.dto.response.HiveDetailResponse;
+import kr.co.webee.presentation.hive.dto.response.HiveListResponse;
+import kr.co.webee.presentation.hive.dto.response.HiveRegisterResponse;
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class HiveServiceTest {
+
+    @Autowired
+    private HiveService hiveService;
+
+    @Autowired
+    private HiveRepository hiveRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private HiveGateActionRepository hiveGateActionRepository;
+
+    @Autowired
+    private HiveBeeCountRepository hiveBeeCountRepository;
+
+    @Autowired
+    private HiveControlRepository hiveControlRepository;
+
+    @Autowired
+    private HiveControlScheduleRepository hiveControlScheduleRepository;
+
+    @Autowired
+    private HiveReplacementHistoryRepository hiveReplacementHistoryRepository;
+
+    @Autowired
+    private HiveTelemetryRepository hiveTelemetryRepository;
+
+    private User user;
+    private Hive hive;
+
+    @BeforeEach
+    void setUp() {
+        hiveGateActionRepository.deleteAllInBatch();
+        hiveBeeCountRepository.deleteAllInBatch();
+        hiveControlRepository.deleteAllInBatch();
+        hiveControlScheduleRepository.deleteAllInBatch();
+        hiveReplacementHistoryRepository.deleteAllInBatch();
+        hiveTelemetryRepository.deleteAllInBatch();
+        hiveRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+
+        user = userRepository.save(TestFixture.createUser("hive-user"));
+        hive = hiveRepository.save(TestFixture.createHive(null, user));
+    }
+
+    @Nested
+    @DisplayName("벌통 등록")
+    class RegisterHive {
+
+        @Test
+        @DisplayName("벌통을 등록한다.")
+        void registerHive() {
+            //given
+            HiveRegisterRequest request = HiveRegisterRequest.builder()
+                    .name("새 벌통")
+                    .region("경기도")
+                    .location("파주시")
+                    .macAddress("11:22:33:44:55:66")
+                    .build();
+
+            //when
+            HiveRegisterResponse response = hiveService.registerHive(request, user.getId());
+
+            //then
+            assertThat(response.hiveId()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("이미 등록된 MAC 주소로 벌통을 등록하려는 경우 예외가 발생한다.")
+        void registerHiveWithDuplicateMacAddress() {
+            //given
+            HiveRegisterRequest request = HiveRegisterRequest.builder()
+                    .name("새 벌통")
+                    .region("경기도")
+                    .location("파주시")
+                    .macAddress("AA:BB:CC:DD:EE:FF")
+                    .build();
+
+            //when - then
+            assertThatThrownBy(() -> hiveService.registerHive(request, user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_MAC_ADDRESS_ALREADY_EXISTS);
+        }
+    }
+
+    @Nested
+    @DisplayName("벌통 목록 조회")
+    class GetAllHives {
+
+        @Test
+        @DisplayName("사용자의 벌통 목록을 조회한다.")
+        void getAllHives() {
+            //when
+            HiveListResponse response = hiveService.getAllHives(user.getId());
+
+            //then
+            assertThat(response.totalCount()).isEqualTo(1);
+            assertThat(response.hives()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("등록된 벌통이 없으면 빈 목록을 반환한다.")
+        void getAllHivesEmpty() {
+            //given
+            User newUser = userRepository.save(TestFixture.createUser("no-hive-user"));
+
+            //when
+            HiveListResponse response = hiveService.getAllHives(newUser.getId());
+
+            //then
+            assertThat(response.totalCount()).isZero();
+            assertThat(response.hives()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("벌통 상세 조회")
+    class GetHiveDetail {
+
+        @Test
+        @DisplayName("벌통 상세 정보를 조회한다.")
+        void getHiveDetail() {
+            //when
+            HiveDetailResponse response = hiveService.getHiveDetail(hive.getId(), user.getId());
+
+            //then
+            assertThat(response.hiveId()).isEqualTo(hive.getId());
+            assertThat(response.name()).isEqualTo("테스트 벌통");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통을 조회하려는 경우 예외가 발생한다.")
+        void getHiveDetailNotFound() {
+            //when - then
+            assertThatThrownBy(() -> hiveService.getHiveDetail(999L, user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 벌통을 조회하려는 경우 예외가 발생한다.")
+        void getHiveDetailOfOtherUser() {
+            //given
+            User otherUser = userRepository.save(TestFixture.createUser("other-user"));
+
+            //when - then
+            assertThatThrownBy(() -> hiveService.getHiveDetail(hive.getId(), otherUser.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("벌통 수정")
+    class UpdateHive {
+
+        @Test
+        @DisplayName("벌통 정보를 수정한다.")
+        void updateHive() {
+            //given
+            HiveUpdateRequest request = HiveUpdateRequest.builder()
+                    .name("수정된 벌통")
+                    .region("경기도")
+                    .location("파주시")
+                    .build();
+
+            //when
+            hiveService.updateHive(hive.getId(), user.getId(), request);
+
+            //then
+            Hive updated = hiveRepository.findById(hive.getId()).orElseThrow();
+            assertThat(updated.getName()).isEqualTo("수정된 벌통");
+            assertThat(updated.getRegion()).isEqualTo("경기도");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통을 수정하려는 경우 예외가 발생한다.")
+        void updateHiveNotFound() {
+            //given
+            HiveUpdateRequest request = HiveUpdateRequest.builder()
+                    .name("수정된 벌통")
+                    .region("경기도")
+                    .location("파주시")
+                    .build();
+
+            //when - then
+            assertThatThrownBy(() -> hiveService.updateHive(999L, user.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("벌통 삭제")
+    class DeleteHive {
+
+        @Test
+        @DisplayName("벌통을 삭제하면 연관된 자식 엔티티도 모두 삭제된다.")
+        void deleteHiveWithChildren() {
+            //given
+            hiveBeeCountRepository.save(TestFixture.createHiveBeeCount(hive));
+            hiveControlRepository.save(TestFixture.createHiveControl(null, hive));
+            hiveControlScheduleRepository.save(TestFixture.createHiveControlSchedule(hive));
+            hiveReplacementHistoryRepository.save(TestFixture.createHiveReplacementHistory(hive));
+            hiveTelemetryRepository.save(TestFixture.createHiveTelemetry(hive));
+            hiveGateActionRepository.save(TestFixture.createHiveGateAction(null, null, null, hive));
+
+            //when
+            hiveService.deleteHive(hive.getId(), user.getId());
+
+            //then
+            assertThat(hiveRepository.findById(hive.getId())).isEmpty();
+            assertThat(hiveBeeCountRepository.findAll()).isEmpty();
+            assertThat(hiveControlRepository.findAll()).isEmpty();
+            assertThat(hiveControlScheduleRepository.findAll()).isEmpty();
+            assertThat(hiveReplacementHistoryRepository.findAll()).isEmpty();
+            assertThat(hiveTelemetryRepository.findAll()).isEmpty();
+            assertThat(hiveGateActionRepository.findAll()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 벌통을 삭제하려는 경우 예외가 발생한다.")
+        void deleteHiveNotFound() {
+            //when - then
+            assertThatThrownBy(() -> hiveService.deleteHive(999L, user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 벌통을 삭제하려는 경우 예외가 발생한다.")
+        void deleteHiveOfOtherUser() {
+            //given
+            User otherUser = userRepository.save(TestFixture.createUser("other-user"));
+
+            //when - then
+            assertThatThrownBy(() -> hiveService.deleteHive(hive.getId(), otherUser.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.HIVE_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/application/product/service/ProductReviewServiceTest.java
+++ b/src/test/java/kr/co/webee/application/product/service/ProductReviewServiceTest.java
@@ -54,10 +54,10 @@ class ProductReviewServiceTest {
 
     @BeforeEach
     void setUp() {
-        productReviewRepository.deleteAll();
-        productRepository.deleteAll();
-        businessRepository.deleteAll();
-        userRepository.deleteAll();
+        productReviewRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+        businessRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
 
         User owner = User.builder().username("ownerUsername").password("ownerPassword").name("ownerName").businessRegistered(false).build();
         userRepository.save(owner);

--- a/src/test/java/kr/co/webee/application/product/service/ProductReviewServiceTest.java
+++ b/src/test/java/kr/co/webee/application/product/service/ProductReviewServiceTest.java
@@ -54,10 +54,10 @@ class ProductReviewServiceTest {
 
     @BeforeEach
     void setUp() {
-        productReviewRepository.deleteAllInBatch();
-        productRepository.deleteAllInBatch();
-        businessRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
+        productReviewRepository.deleteAll();
+        productRepository.deleteAll();
+        businessRepository.deleteAll();
+        userRepository.deleteAll();
 
         User owner = User.builder().username("ownerUsername").password("ownerPassword").name("ownerName").businessRegistered(false).build();
         userRepository.save(owner);

--- a/src/test/java/kr/co/webee/support/util/TestFixture.java
+++ b/src/test/java/kr/co/webee/support/util/TestFixture.java
@@ -1,10 +1,18 @@
 package kr.co.webee.support.util;
 
 import kr.co.webee.domain.hive.entity.Hive;
+import kr.co.webee.domain.hive.entity.HiveBeeCount;
+import kr.co.webee.domain.hive.entity.HiveControl;
+import kr.co.webee.domain.hive.entity.HiveControlSchedule;
 import kr.co.webee.domain.hive.entity.HiveGateAction;
+import kr.co.webee.domain.hive.entity.HiveReplacementHistory;
+import kr.co.webee.domain.hive.entity.HiveTelemetry;
+import kr.co.webee.domain.hive.type.ControlType;
 import kr.co.webee.domain.hive.type.GateActionType;
 import kr.co.webee.domain.user.entity.User;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public class TestFixture {
@@ -35,6 +43,48 @@ public class TestFixture {
                 .actionType(actionType != null ? actionType : GateActionType.OPEN_ONLY)
                 .actionTime(actionTime != null ? actionTime : LocalTime.of(9, 0))
                 .repeatEnabled(false)
+                .build();
+    }
+
+    public static HiveBeeCount createHiveBeeCount(Hive hive) {
+        return HiveBeeCount.builder()
+                .hive(hive)
+                .count(100)
+                .recordedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static HiveControl createHiveControl(ControlType type, Hive hive) {
+        return HiveControl.builder()
+                .hive(hive)
+                .type(type != null ? type : ControlType.FAN)
+                .autoEnabled(false)
+                .manualEnabled(false)
+                .isOn(false)
+                .build();
+    }
+
+    public static HiveControlSchedule createHiveControlSchedule(Hive hive) {
+        return HiveControlSchedule.builder()
+                .hive(hive)
+                .startTime(LocalTime.of(8, 0))
+                .endTime(LocalTime.of(18, 0))
+                .enabled(true)
+                .build();
+    }
+
+    public static HiveReplacementHistory createHiveReplacementHistory(Hive hive) {
+        return HiveReplacementHistory.builder()
+                .hive(hive)
+                .replacedAt(LocalDate.now())
+                .build();
+    }
+
+    public static HiveTelemetry createHiveTelemetry(Hive hive) {
+        return HiveTelemetry.builder()
+                .hive(hive)
+                .internalTemperature(25.0)
+                .recordedAt(LocalDateTime.now())
                 .build();
     }
 }


### PR DESCRIPTION
## 🧷 이슈

- close #

## 🔨 작업 내용

- Hive 삭제 시 FK 제약 오류 수정
  - `@OneToMany + CascadeType.REMOVE` 제거 후 각 자식 Repository에 `deleteAllByHiveId` bulk DELETE 추가 (2e72d11)
  - `HiveService.deleteHive()`에서 자식 테이블 6개 bulk DELETE 후 부모 삭제 (2e72d11)
- HiveService 테스트 작성
  - `HiveServiceTest` 신규 작성 — 등록/조회/수정/삭제 전 케이스 포함, 삭제 시 자식 엔티티 전체 삭제 검증 (48b7ad7)
  - `TestFixture`에 HiveBeeCount, HiveControl, HiveControlSchedule, HiveReplacementHistory, HiveTelemetry 픽스처 추가 (48b7ad7)
- 테스트 setUp 개선
  - 전체 서비스 테스트의 `deleteAll()`을 `deleteAllInBatch()`로 교체 (6ce2ffc)