### PR TITLE
feat: 뉴스 API

### DIFF
--- a/src/main/java/kr/co/webee/WebeeApplication.java
+++ b/src/main/java/kr/co/webee/WebeeApplication.java
@@ -2,7 +2,6 @@ package kr.co.webee;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class WebeeApplication {

--- a/src/main/java/kr/co/webee/application/news/scheduler/NewsScheduler.java
+++ b/src/main/java/kr/co/webee/application/news/scheduler/NewsScheduler.java
@@ -1,0 +1,23 @@
+package kr.co.webee.application.news.scheduler;
+
+import kr.co.webee.application.news.service.NewsCollectService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NewsScheduler {
+
+    private final NewsCollectService newsCollectService;
+
+    @Scheduled(cron = "0 0 */6 * * *")
+    public void collectNewsArticles() {
+        newsCollectService.collectNewsArticles();
+        log.info("뉴스 수집 스케줄링 완료. fetchedAt={}", LocalDateTime.now());
+    }
+}

--- a/src/main/java/kr/co/webee/application/news/service/NewsCollectService.java
+++ b/src/main/java/kr/co/webee/application/news/service/NewsCollectService.java
@@ -1,0 +1,32 @@
+package kr.co.webee.application.news.service;
+
+import kr.co.webee.domain.interestnewskeyword.repository.InterestNewsKeywordRepository;
+import kr.co.webee.infrastructure.news.client.NewsClient;
+import kr.co.webee.infrastructure.news.dto.NaverNewsResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class NewsCollectService {
+    private static final List<String> DEFAULT_KEYWORDS = List.of("수정벌", "꿀벌", "호박벌", "양봉");
+    private final NewsClient newsClient;
+    private final NewsService newsService;
+    private final InterestNewsKeywordRepository interestNewsKeywordRepository;
+
+    public void collectNewsArticles() {
+        Set<String> keywords = new HashSet<>(DEFAULT_KEYWORDS);
+        keywords.addAll(interestNewsKeywordRepository.findAllDistinctKeywords());
+
+        for (String keyword : keywords) {
+            NaverNewsResponse response = newsClient.fetchNews(keyword);
+            newsService.addNewsArticleByKeyword(keyword, response.items());
+        }
+    }
+}

--- a/src/main/java/kr/co/webee/application/news/service/NewsService.java
+++ b/src/main/java/kr/co/webee/application/news/service/NewsService.java
@@ -1,0 +1,63 @@
+package kr.co.webee.application.news.service;
+
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.news.entity.NewsArticle;
+import kr.co.webee.domain.news.entity.NewsArticleKeyword;
+import kr.co.webee.domain.news.repository.NewsArticleKeywordRepository;
+import kr.co.webee.domain.news.repository.NewsArticleRepository;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.infrastructure.news.dto.NaverNewsResponse.Item;
+import kr.co.webee.presentation.news.dto.response.NewsArticleDetailResponse;
+import kr.co.webee.presentation.news.dto.response.NewsArticleListResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+    private final NewsArticleRepository newsArticleRepository;
+    private final NewsArticleKeywordRepository newsArticleKeywordRepository;
+
+    @Transactional(readOnly = true)
+    public Slice<NewsArticleListResponse> getAllNewsArticleList(String keyword, Pageable pageable) {
+        return newsArticleRepository.findAllByKeyword(keyword, pageable)
+                .map(NewsArticleListResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public NewsArticleDetailResponse getNewsArticleDetail(Long newsArticleId) {
+        NewsArticle article = newsArticleRepository.findById(newsArticleId)
+                .orElseThrow(() -> new BusinessException(ErrorType.ENTITY_NOT_FOUND));
+
+        return NewsArticleDetailResponse.from(article);
+    }
+
+    @Transactional
+    public void addNewsArticleByKeyword(String keyword, List<Item> news) {
+        for (Item item : news) {
+            newsArticleRepository.findByOriginalLink(item.originalLink())
+                    .ifPresentOrElse(
+                            // 기존에 동일 뉴스가 존재하고 키워드 연결 안된 경우, 키워드만 연결 추가
+                            article -> {
+                                if (!newsArticleKeywordRepository.existsByNewsArticleIdAndKeyword(article.getId(), keyword)) {
+                                    newsArticleKeywordRepository.save(NewsArticleKeyword.create(article, keyword));
+                                }
+                            },
+
+                            // 새로운 뉴스일 경우 뉴스 및 키워드 저장
+                            () -> {
+                                NewsArticle article = newsArticleRepository.save(item.toEntity(LocalDateTime.now()));
+                                newsArticleKeywordRepository.save(NewsArticleKeyword.create(article, keyword));
+                            }
+                    );
+        }
+    }
+}

--- a/src/main/java/kr/co/webee/domain/interestnewskeyword/repository/InterestNewsKeywordRepository.java
+++ b/src/main/java/kr/co/webee/domain/interestnewskeyword/repository/InterestNewsKeywordRepository.java
@@ -2,6 +2,7 @@ package kr.co.webee.domain.interestnewskeyword.repository;
 
 import kr.co.webee.domain.interestnewskeyword.entity.InterestNewsKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,5 +10,8 @@ import java.util.List;
 @Repository
 public interface InterestNewsKeywordRepository extends JpaRepository<InterestNewsKeyword, Long> {
     List<InterestNewsKeyword> findByUserId(Long userId);
+
+    @Query("SELECT DISTINCT k.keyword FROM InterestNewsKeyword k")
+    List<String> findAllDistinctKeywords();
 }
 

--- a/src/main/java/kr/co/webee/domain/news/entity/NewsArticle.java
+++ b/src/main/java/kr/co/webee/domain/news/entity/NewsArticle.java
@@ -1,0 +1,63 @@
+package kr.co.webee.domain.news.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class NewsArticle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String summary;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column
+    private String source;
+
+    @Column(nullable = false, unique = true)
+    private String originalLink;
+
+    private LocalDateTime publishedAt;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime fetchedAt;
+
+    @Builder
+    private NewsArticle(String title, String summary, String content, String source,
+                        String originalLink, LocalDateTime publishedAt, LocalDateTime fetchedAt) {
+        if (!StringUtils.hasText(title)) {
+            throw new IllegalArgumentException("title은 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+        if (!StringUtils.hasText(originalLink)) {
+            throw new IllegalArgumentException("originalLink는 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+        this.title = title;
+        this.summary = summary;
+        this.content = content;
+        this.source = source;
+        this.originalLink = originalLink;
+        this.publishedAt = publishedAt;
+        this.fetchedAt = Objects.requireNonNull(fetchedAt, "fetchedAt은 null이 될 수 없습니다.");
+    }
+}

--- a/src/main/java/kr/co/webee/domain/news/entity/NewsArticleKeyword.java
+++ b/src/main/java/kr/co/webee/domain/news/entity/NewsArticleKeyword.java
@@ -1,0 +1,50 @@
+package kr.co.webee.domain.news.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class NewsArticleKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_article_id", nullable = false)
+    private NewsArticle newsArticle;
+
+    @Column(nullable = false)
+    private String keyword;
+
+    public static NewsArticleKeyword create(NewsArticle newsArticle, String keyword) {
+        return NewsArticleKeyword.builder()
+                .newsArticle(newsArticle)
+                .keyword(keyword)
+                .build();
+    }
+
+    @Builder
+    private NewsArticleKeyword(NewsArticle newsArticle, String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            throw new IllegalArgumentException("keyword는 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+        this.newsArticle = Objects.requireNonNull(newsArticle, "newsArticle은 null이 될 수 없습니다.");
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/kr/co/webee/domain/news/repository/NewsArticleKeywordRepository.java
+++ b/src/main/java/kr/co/webee/domain/news/repository/NewsArticleKeywordRepository.java
@@ -1,0 +1,10 @@
+package kr.co.webee.domain.news.repository;
+
+import kr.co.webee.domain.news.entity.NewsArticleKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsArticleKeywordRepository extends JpaRepository<NewsArticleKeyword, Long> {
+    boolean existsByNewsArticleIdAndKeyword(Long newsArticleId, String keyword);
+}

--- a/src/main/java/kr/co/webee/domain/news/repository/NewsArticleRepository.java
+++ b/src/main/java/kr/co/webee/domain/news/repository/NewsArticleRepository.java
@@ -1,0 +1,26 @@
+package kr.co.webee.domain.news.repository;
+
+import kr.co.webee.domain.news.entity.NewsArticle;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> {
+    boolean existsByOriginalLink(String originalLink);
+    Optional<NewsArticle> findByOriginalLink(String originalLink);
+
+    @Query("""
+            SELECT a
+            FROM NewsArticle a
+            JOIN NewsArticleKeyword k ON k.newsArticle = a
+            WHERE k.keyword = :keyword
+            ORDER BY a.publishedAt DESC, a.id DESC
+            """)
+    Slice<NewsArticle> findAllByKeyword(@Param("keyword") String keyword, Pageable pageable);
+}

--- a/src/main/java/kr/co/webee/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/kr/co/webee/infrastructure/config/SchedulingConfig.java
@@ -1,0 +1,11 @@
+package kr.co.webee.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+@Profile("!test")
+public class SchedulingConfig {
+}

--- a/src/main/java/kr/co/webee/infrastructure/news/client/NaverNewsClient.java
+++ b/src/main/java/kr/co/webee/infrastructure/news/client/NaverNewsClient.java
@@ -1,0 +1,49 @@
+package kr.co.webee.infrastructure.news.client;
+
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.infrastructure.news.dto.NaverNewsResponse;
+import kr.co.webee.infrastructure.news.properties.NewsProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Slf4j
+@Component
+public class NaverNewsClient implements NewsClient {
+    private static final int DISPLAY = 100;
+
+    private final RestClient restClient;
+    private final NewsProperties newsProperties;
+
+    public NaverNewsClient(NewsProperties newsProperties) {
+        this.restClient = RestClient.create();
+        this.newsProperties = newsProperties;
+    }
+
+    @Override
+    public NaverNewsResponse fetchNews(String keyword) {
+        URI uri = UriComponentsBuilder.fromHttpUrl(newsProperties.getApiUrl())
+                .queryParam("query", keyword)
+                .queryParam("display", DISPLAY)
+                .queryParam("sort", "date")
+                .build()
+                .encode()
+                .toUri();
+
+        try {
+            return restClient.get()
+                    .uri(uri)
+                    .header("X-Naver-Client-Id", newsProperties.getClientId())
+                    .header("X-Naver-Client-Secret", newsProperties.getClientSecret())
+                    .retrieve()
+                    .body(NaverNewsResponse.class);
+        } catch (Exception e) {
+            log.error("네이버 뉴스 API 호출 실패. keyword={}, error={}", keyword, e.getMessage());
+            throw new BusinessException(ErrorType.UNHANDLED_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/kr/co/webee/infrastructure/news/client/NewsClient.java
+++ b/src/main/java/kr/co/webee/infrastructure/news/client/NewsClient.java
@@ -1,0 +1,7 @@
+package kr.co.webee.infrastructure.news.client;
+
+import kr.co.webee.infrastructure.news.dto.NaverNewsResponse;
+
+public interface NewsClient {
+    NaverNewsResponse fetchNews(String keyword);
+}

--- a/src/main/java/kr/co/webee/infrastructure/news/dto/NaverNewsResponse.java
+++ b/src/main/java/kr/co/webee/infrastructure/news/dto/NaverNewsResponse.java
@@ -1,0 +1,48 @@
+package kr.co.webee.infrastructure.news.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import kr.co.webee.domain.news.entity.NewsArticle;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+
+public record NaverNewsResponse(
+        int total,
+        int display,
+        List<Item> items
+) {
+    public record Item(
+            String title,
+            String description,
+            @JsonProperty("originallink") String originalLink,
+            String link,
+            String pubDate
+    ) {
+        public NewsArticle toEntity(LocalDateTime fetchedAt) {
+            return NewsArticle.builder()
+                    .title(stripHtml(title))
+                    .summary(stripHtml(description))
+                    .originalLink(originalLink)
+                    .publishedAt(parseToLocalDateTime(pubDate))
+                    .fetchedAt(fetchedAt)
+                    .build();
+        }
+
+        private LocalDateTime parseToLocalDateTime(String pubDate) {
+            ZonedDateTime zonedDateTime = ZonedDateTime.parse(pubDate, DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH));
+            return zonedDateTime.toLocalDateTime();
+        }
+
+        private static String stripHtml(String html) {
+            return html.replaceAll("<[^>]+>", "")
+                    .replace("&amp;", "&")
+                    .replace("&lt;", "<")
+                    .replace("&gt;", ">")
+                    .replace("&quot;", "\"")
+                    .replace("&#39;", "'");
+        }
+    }
+}

--- a/src/main/java/kr/co/webee/infrastructure/news/properties/NewsProperties.java
+++ b/src/main/java/kr/co/webee/infrastructure/news/properties/NewsProperties.java
@@ -1,0 +1,16 @@
+package kr.co.webee.infrastructure.news.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Setter
+@Getter
+@ConfigurationProperties(prefix = "news")
+@Component
+public class NewsProperties {
+    private String clientId;
+    private String clientSecret;
+    private String apiUrl;
+}

--- a/src/main/java/kr/co/webee/presentation/news/api/NewsApi.java
+++ b/src/main/java/kr/co/webee/presentation/news/api/NewsApi.java
@@ -1,0 +1,47 @@
+package kr.co.webee.presentation.news.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import kr.co.webee.presentation.news.dto.response.NewsArticleDetailResponse;
+import kr.co.webee.presentation.news.dto.response.NewsArticleListResponse;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "News", description = "뉴스 기사 API")
+public interface NewsApi {
+
+    @Operation(
+            summary = "뉴스 기사 목록 조회",
+            description = "키워드에 해당하는 뉴스 기사 목록을 Slice 단위로 조회합니다. 기본값은 size=5, 발행일 내림차순입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "뉴스 기사 목록 조회 성공"),
+    })
+    Slice<NewsArticleListResponse> getAllNewsArticleList(
+            @Parameter(description = "검색 키워드", example = "꿀벌", required = true)
+            @RequestParam String keyword,
+
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "페이지 크기", example = "5")
+            @RequestParam(defaultValue = "5") int size
+    );
+
+    @Operation(
+            summary = "뉴스 기사 상세 조회",
+            description = "뉴스 기사 ID에 해당하는 기사 상세를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "뉴스 기사 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "뉴스 기사 없음"),
+    })
+    NewsArticleDetailResponse getNewsArticleDetail(
+            @Parameter(description = "뉴스 기사 ID", example = "101", required = true)
+            @PathVariable Long newsArticleId
+    );
+}

--- a/src/main/java/kr/co/webee/presentation/news/controller/NewsController.java
+++ b/src/main/java/kr/co/webee/presentation/news/controller/NewsController.java
@@ -1,0 +1,36 @@
+package kr.co.webee.presentation.news.controller;
+
+import kr.co.webee.application.news.service.NewsService;
+import kr.co.webee.presentation.news.api.NewsApi;
+import kr.co.webee.presentation.news.dto.response.NewsArticleDetailResponse;
+import kr.co.webee.presentation.news.dto.response.NewsArticleListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/news")
+public class NewsController implements NewsApi {
+
+    private final NewsService newsService;
+
+    @GetMapping
+    public Slice<NewsArticleListResponse> getAllNewsArticleList(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        return newsService.getAllNewsArticleList(keyword, PageRequest.of(page, size));
+    }
+
+    @GetMapping("/{newsArticleId}")
+    public NewsArticleDetailResponse getNewsArticleDetail(@PathVariable Long newsArticleId) {
+        return newsService.getNewsArticleDetail(newsArticleId);
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/news/dto/response/NewsArticleDetailResponse.java
+++ b/src/main/java/kr/co/webee/presentation/news/dto/response/NewsArticleDetailResponse.java
@@ -1,0 +1,36 @@
+package kr.co.webee.presentation.news.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.domain.news.entity.NewsArticle;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "뉴스 기사 상세 response")
+public record NewsArticleDetailResponse(
+        @Schema(description = "뉴스 기사 ID", example = "101")
+        Long newsArticleId,
+
+        @Schema(description = "제목", example = "수정벌 방사 시기, 기온 체크가 관건")
+        String title,
+
+        @Schema(description = "내용", example = "과수 농가에서 수정벌 방사 전 확인해야 할 사항...")
+        String content,
+
+        @Schema(description = "출처", example = "농민신문")
+        String source,
+
+        @Schema(description = "발행 일시", example = "2026-06-16T09:00:00")
+        LocalDateTime publishedAt
+) {
+    public static NewsArticleDetailResponse from(NewsArticle article) {
+        return NewsArticleDetailResponse.builder()
+                .newsArticleId(article.getId())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .source(article.getSource())
+                .publishedAt(article.getPublishedAt())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/news/dto/response/NewsArticleListResponse.java
+++ b/src/main/java/kr/co/webee/presentation/news/dto/response/NewsArticleListResponse.java
@@ -1,0 +1,32 @@
+package kr.co.webee.presentation.news.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.domain.news.entity.NewsArticle;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "뉴스 기사 목록 항목 response")
+public record NewsArticleListResponse(
+        @Schema(description = "뉴스 기사 ID", example = "101")
+        Long newsArticleId,
+
+        @Schema(description = "제목", example = "수정벌 방사 시기, 기온 체크가 관건")
+        String title,
+
+        @Schema(description = "출처", example = "농민신문")
+        String source,
+
+        @Schema(description = "발행 일시", example = "2026-06-16T09:00:00")
+        LocalDateTime publishedAt
+) {
+    public static NewsArticleListResponse from(NewsArticle article) {
+        return NewsArticleListResponse.builder()
+                .newsArticleId(article.getId())
+                .title(article.getTitle())
+                .source(article.getSource())
+                .publishedAt(article.getPublishedAt())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -163,3 +163,8 @@ rabbitmq:
   queue-name: ${RABBITMQ_QUEUE_NAME:queue}
   exchange-name: ${RABBITMQ_EXCHANGE_NAME:exchange}
   routing-key: ${RABBITMQ_ROUTING_KEY:key}
+
+news:
+  api-Url: ${NEWS_API_URL:}
+  client-id: ${NEWS_CLIENT_ID:}
+  client-secret: ${NEWS_CLIENT_SECRET:}

--- a/src/main/resources/db/migration/V3__create_news_article.sql
+++ b/src/main/resources/db/migration/V3__create_news_article.sql
@@ -1,0 +1,24 @@
+CREATE TABLE news_article
+(
+    id            BIGINT       NOT NULL AUTO_INCREMENT,
+    title         VARCHAR(300) NOT NULL,
+    summary       VARCHAR(500),
+    content       TEXT,
+    source        VARCHAR(50),
+    original_link VARCHAR(500) NOT NULL,
+    published_at  DATETIME,
+    fetched_at    DATETIME     NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_news_article_original_link (original_link)
+);
+
+CREATE TABLE news_article_keyword
+(
+    id              BIGINT      NOT NULL AUTO_INCREMENT,
+    news_article_id BIGINT      NOT NULL,
+    keyword         VARCHAR(20) NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_news_article_keyword (news_article_id, keyword),
+    CONSTRAINT fk_news_article_keyword_article
+        FOREIGN KEY (news_article_id) REFERENCES news_article (id)
+);

--- a/src/test/java/kr/co/webee/application/news/service/NewsCollectServiceTest.java
+++ b/src/test/java/kr/co/webee/application/news/service/NewsCollectServiceTest.java
@@ -1,0 +1,87 @@
+package kr.co.webee.application.news.service;
+
+import kr.co.webee.annotation.IntegrationTest;
+import kr.co.webee.domain.news.repository.NewsArticleKeywordRepository;
+import kr.co.webee.domain.news.repository.NewsArticleRepository;
+import kr.co.webee.infrastructure.news.client.NewsClient;
+import kr.co.webee.infrastructure.news.dto.NaverNewsResponse;
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@IntegrationTest
+class NewsCollectServiceTest {
+
+    @Autowired
+    private NewsCollectService newsCollectService;
+
+    @Autowired
+    private NewsArticleRepository newsArticleRepository;
+
+    @Autowired
+    private NewsArticleKeywordRepository newsArticleKeywordRepository;
+
+    @MockitoBean
+    private NewsClient newsClient;
+
+    @BeforeEach
+    void setUp() {
+        newsArticleKeywordRepository.deleteAllInBatch();
+        newsArticleRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("뉴스 기사 수집")
+    class CollectNewsArticles {
+
+        private final NaverNewsResponse emptyResponse = new NaverNewsResponse(0, 0, List.of());
+
+        private NaverNewsResponse singleItemResponse(String title, String originalLink) {
+            return new NaverNewsResponse(1, 1, List.of(
+                    new NaverNewsResponse.Item(title, "테스트 요약", originalLink, originalLink,
+                            "Tue, 16 Jun 2026 09:00:00 +0900")
+            ));
+        }
+
+        @Test
+        @DisplayName("기본 키워드에 해당하는 기사를 수집하여 저장한다.")
+        void collectNewsArticles_savesArticlesForDefaultKeywords() {
+            //given
+            when(newsClient.fetchNews(anyString())).thenReturn(emptyResponse);
+            when(newsClient.fetchNews(eq("꿀벌"))).thenReturn(
+                    singleItemResponse("꿀벌 기사", "https://news.example.com/1"));
+
+            //when
+            newsCollectService.collectNewsArticles();
+
+            //then
+            assertThat(newsArticleRepository.count()).isEqualTo(1);
+            assertThat(newsArticleKeywordRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("빈 응답이면 기사를 저장하지 않는다.")
+        void collectNewsArticles_emptyResponse() {
+            //given
+            when(newsClient.fetchNews(anyString())).thenReturn(emptyResponse);
+
+            //when
+            newsCollectService.collectNewsArticles();
+
+            //then
+            assertThat(newsArticleRepository.count()).isEqualTo(0);
+            assertThat(newsArticleKeywordRepository.count()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/application/news/service/NewsServiceTest.java
+++ b/src/test/java/kr/co/webee/application/news/service/NewsServiceTest.java
@@ -1,0 +1,173 @@
+package kr.co.webee.application.news.service;
+
+import kr.co.webee.annotation.IntegrationTest;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.news.entity.NewsArticle;
+import kr.co.webee.domain.news.repository.NewsArticleKeywordRepository;
+import kr.co.webee.domain.news.repository.NewsArticleRepository;
+import kr.co.webee.infrastructure.news.dto.NaverNewsResponse;
+import kr.co.webee.presentation.news.dto.response.NewsArticleDetailResponse;
+import kr.co.webee.presentation.news.dto.response.NewsArticleListResponse;
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class NewsServiceTest {
+
+    @Autowired
+    private NewsService newsService;
+
+    @Autowired
+    private NewsArticleRepository newsArticleRepository;
+
+    @Autowired
+    private NewsArticleKeywordRepository newsArticleKeywordRepository;
+
+    @BeforeEach
+    void setUp() {
+        newsArticleKeywordRepository.deleteAllInBatch();
+        newsArticleRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("뉴스 기사 목록 조회")
+    class GetAllNewsArticleList {
+
+        @Test
+        @DisplayName("키워드에 해당하는 뉴스 기사 목록을 반환한다.")
+        void getAllNewsArticleList() {
+            //given
+            NewsArticle article1 = newsArticleRepository.save(
+                    TestFixture.createNewsArticle("꿀벌 기사1", "https://news.example.com/1"));
+            NewsArticle article2 = newsArticleRepository.save(
+                    TestFixture.createNewsArticle("꿀벌 기사2", "https://news.example.com/2"));
+            newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article1, "꿀벌"));
+            newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article2, "꿀벌"));
+
+            //when
+            Slice<NewsArticleListResponse> result = newsService.getAllNewsArticleList("꿀벌", PageRequest.of(0, 10));
+
+            //then
+            assertThat(result.getContent()).hasSize(2)
+                    .extracting("title")
+                    .containsExactlyInAnyOrder("꿀벌 기사1", "꿀벌 기사2");
+        }
+
+        @Test
+        @DisplayName("해당 키워드의 기사가 없으면 빈 목록을 반환한다.")
+        void getAllNewsArticleListEmpty() {
+            //when
+            Slice<NewsArticleListResponse> result = newsService.getAllNewsArticleList("꿀벌", PageRequest.of(0, 10));
+
+            //then
+            assertThat(result.getContent()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("뉴스 기사 상세 조회")
+    class GetNewsArticleDetail {
+
+        @Test
+        @DisplayName("뉴스 기사 상세를 조회한다.")
+        void getNewsArticleDetail() {
+            //given
+            NewsArticle article = newsArticleRepository.save(
+                    TestFixture.createNewsArticle("수정벌 방사 시기, 기온 체크가 관건", "https://news.example.com/1"));
+
+            //when
+            NewsArticleDetailResponse result = newsService.getNewsArticleDetail(article.getId());
+
+            //then
+            assertThat(result.newsArticleId()).isEqualTo(article.getId());
+            assertThat(result.title()).isEqualTo("수정벌 방사 시기, 기온 체크가 관건");
+            assertThat(result.source()).isEqualTo("테스트 언론사");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 뉴스 기사를 조회하면 예외가 발생한다.")
+        void getNewsArticleDetailNotFound() {
+            //when - then
+            assertThatThrownBy(() -> newsService.getNewsArticleDetail(-1L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.ENTITY_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("키워드별 뉴스 기사 저장")
+    class AddNewsArticleByKeyword {
+
+        private List<NaverNewsResponse.Item> singleItem(String title, String originalLink) {
+            return List.of(new NaverNewsResponse.Item(
+                    title, "테스트 요약", originalLink, originalLink,
+                    "Tue, 16 Jun 2026 09:00:00 +0900"));
+        }
+
+        @Test
+        @DisplayName("새로운 기사이면 저장한다.")
+        void addNewsArticleByKeyword_savesNewArticle() {
+            //when
+            newsService.addNewsArticleByKeyword("꿀벌", singleItem("꿀벌 기사", "https://news.example.com/1"));
+
+            //then
+            assertThat(newsArticleRepository.count()).isEqualTo(1);
+            assertThat(newsArticleKeywordRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 기사에 연결되지 않은 키워드이면 키워드를 추가한다.")
+        void addNewsArticleByKeyword_addsKeywordToExistingArticle() {
+            //given
+            NewsArticle article = newsArticleRepository.save(
+                    TestFixture.createNewsArticle("꿀벌 기사", "https://news.example.com/1"));
+            newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article, "꿀벌"));
+
+            //when
+            newsService.addNewsArticleByKeyword("양봉", singleItem("꿀벌 기사", "https://news.example.com/1"));
+
+            //then
+            assertThat(newsArticleRepository.count()).isEqualTo(1);
+            assertThat(newsArticleKeywordRepository.count()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("이미 연결된 키워드는 중복 저장하지 않는다.")
+        void addNewsArticleByKeyword_doesNotDuplicateKeyword() {
+            //given
+            NewsArticle article = newsArticleRepository.save(
+                    TestFixture.createNewsArticle("꿀벌 기사", "https://news.example.com/1"));
+            newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article, "꿀벌"));
+
+            //when
+            newsService.addNewsArticleByKeyword("꿀벌", singleItem("꿀벌 기사", "https://news.example.com/1"));
+
+            //then
+            assertThat(newsArticleKeywordRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("빈 목록이면 저장하지 않는다.")
+        void addNewsArticleByKeyword_emptyItems() {
+            //when
+            newsService.addNewsArticleByKeyword("꿀벌", List.of());
+
+            //then
+            assertThat(newsArticleRepository.count()).isEqualTo(0);
+            assertThat(newsArticleKeywordRepository.count()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/domain/news/repository/NewsArticleRepositoryTest.java
+++ b/src/test/java/kr/co/webee/domain/news/repository/NewsArticleRepositoryTest.java
@@ -1,0 +1,93 @@
+package kr.co.webee.domain.news.repository;
+
+import kr.co.webee.domain.annotation.RepositoryTest;
+import kr.co.webee.domain.news.entity.NewsArticle;
+import kr.co.webee.domain.news.entity.NewsArticleKeyword;
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+class NewsArticleRepositoryTest {
+
+    @Autowired
+    private NewsArticleRepository newsArticleRepository;
+
+    @Autowired
+    private NewsArticleKeywordRepository newsArticleKeywordRepository;
+
+    @Nested
+    @DisplayName("키워드로 뉴스 기사 목록 조회")
+    class FindAllByKeyword {
+
+        @Test
+        @DisplayName("키워드에 해당하는 뉴스 기사 목록을 발행일 내림차순으로 반환한다.")
+        void findAllByKeyword() {
+            //given
+            NewsArticle article1 = newsArticleRepository.save(
+                    TestFixture.createNewsArticle("꿀벌 기사1", "https://news.example.com/1"));
+            NewsArticle article2 = newsArticleRepository.save(
+                    TestFixture.createNewsArticle("꿀벌 기사2", "https://news.example.com/2"));
+            newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article1, "꿀벌"));
+            newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article2, "꿀벌"));
+
+            //when
+            Slice<NewsArticle> result = newsArticleRepository.findAllByKeyword("꿀벌", PageRequest.of(0, 10));
+
+            //then
+            assertThat(result.getContent()).hasSize(2)
+                    .extracting("title")
+                    .containsExactlyInAnyOrder("꿀벌 기사1", "꿀벌 기사2");
+        }
+
+        @Test
+        @DisplayName("다른 키워드의 기사는 조회되지 않는다.")
+        void findAllByKeywordOtherKeywordExcluded() {
+            //given
+            NewsArticle article = newsArticleRepository.save(
+                    TestFixture.createNewsArticle("양봉 기사", "https://news.example.com/3"));
+            newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article, "양봉"));
+
+            //when
+            Slice<NewsArticle> result = newsArticleRepository.findAllByKeyword("꿀벌", PageRequest.of(0, 10));
+
+            //then
+            assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("해당 키워드의 기사가 없으면 빈 결과를 반환한다.")
+        void findAllByKeywordEmpty() {
+            //when
+            Slice<NewsArticle> result = newsArticleRepository.findAllByKeyword("꿀벌", PageRequest.of(0, 10));
+
+            //then
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("size보다 많은 기사가 있으면 hasNext가 true이다.")
+        void findAllByKeywordHasNext() {
+            //given
+            for (int i = 1; i <= 3; i++) {
+                NewsArticle article = newsArticleRepository.save(
+                        TestFixture.createNewsArticle("꿀벌 기사" + i, "https://news.example.com/" + i));
+                newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article, "꿀벌"));
+            }
+
+            //when
+            Slice<NewsArticle> result = newsArticleRepository.findAllByKeyword("꿀벌", PageRequest.of(0, 2));
+
+            //then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.hasNext()).isTrue();
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/presentation/news/controller/NewsControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/news/controller/NewsControllerTest.java
@@ -1,0 +1,143 @@
+package kr.co.webee.presentation.news.controller;
+
+import kr.co.webee.application.news.service.NewsService;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.config.TestWebConfig;
+import kr.co.webee.presentation.config.WebConfig;
+import kr.co.webee.presentation.news.dto.response.NewsArticleDetailResponse;
+import kr.co.webee.presentation.news.dto.response.NewsArticleListResponse;
+import kr.co.webee.presentation.support.resolver.UserIdArgumentResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestWebConfig.class)
+@WebMvcTest(
+        controllers = NewsController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OncePerRequestFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UserIdArgumentResolver.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)
+        }
+)
+@ActiveProfiles("test")
+class NewsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NewsService newsService;
+
+    @Nested
+    @DisplayName("뉴스 기사 목록 조회")
+    class GetAllNewsArticleList {
+
+        @Test
+        @DisplayName("키워드에 해당하는 뉴스 기사 목록을 조회한다.")
+        void getAllNewsArticleList() throws Exception {
+            //given
+            List<NewsArticleListResponse> articles = List.of(
+                    new NewsArticleListResponse(1L, "꿀벌 관련 뉴스", "농민신문", LocalDateTime.of(2026, 6, 16, 9, 0)),
+                    new NewsArticleListResponse(2L, "양봉 관련 뉴스", "한국농어민신문", LocalDateTime.of(2026, 6, 15, 9, 0))
+            );
+            when(newsService.getAllNewsArticleList(anyString(), any()))
+                    .thenReturn(new SliceImpl<>(articles, PageRequest.of(0, 5), false));
+
+            //when - then
+            mockMvc.perform(get("/api/v1/news")
+                            .param("keyword", "꿀벌")
+                            .param("page", "0")
+                            .param("size", "5"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(2))
+                    .andExpect(jsonPath("$.data.content[0].newsArticleId").value(1L))
+                    .andExpect(jsonPath("$.data.content[0].title").value("꿀벌 관련 뉴스"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("해당 키워드의 기사가 없으면 빈 목록을 반환한다.")
+        void getAllNewsArticleListEmpty() throws Exception {
+            //given
+            when(newsService.getAllNewsArticleList(anyString(), any()))
+                    .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 5), false));
+
+            //when - then
+            mockMvc.perform(get("/api/v1/news")
+                            .param("keyword", "꿀벌"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(0))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("뉴스 기사 상세 조회")
+    class GetNewsArticleDetail {
+
+        @Test
+        @DisplayName("뉴스 기사 상세를 조회한다.")
+        void getNewsArticleDetail() throws Exception {
+            //given
+            NewsArticleDetailResponse response = new NewsArticleDetailResponse(
+                    1L, "수정벌 방사 시기, 기온 체크가 관건",
+                    "과수 농가에서 수정벌 방사 전 확인해야 할 사항...",
+                    "농민신문", LocalDateTime.of(2026, 6, 16, 9, 0)
+            );
+            when(newsService.getNewsArticleDetail(anyLong())).thenReturn(response);
+
+            //when - then
+            mockMvc.perform(get("/api/v1/news/{newsArticleId}", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data.newsArticleId").value(1L))
+                    .andExpect(jsonPath("$.data.title").value("수정벌 방사 시기, 기온 체크가 관건"))
+                    .andExpect(jsonPath("$.data.source").value("농민신문"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 뉴스 기사를 조회하면 404를 반환한다.")
+        void getNewsArticleDetailNotFound() throws Exception {
+            //given
+            when(newsService.getNewsArticleDetail(anyLong()))
+                    .thenThrow(new BusinessException(ErrorType.ENTITY_NOT_FOUND));
+
+            //when - then
+            mockMvc.perform(get("/api/v1/news/{newsArticleId}", -1L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value(ErrorType.ENTITY_NOT_FOUND.getCode()))
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/support/util/TestFixture.java
+++ b/src/test/java/kr/co/webee/support/util/TestFixture.java
@@ -9,6 +9,8 @@ import kr.co.webee.domain.hive.entity.HiveReplacementHistory;
 import kr.co.webee.domain.hive.entity.HiveTelemetry;
 import kr.co.webee.domain.hive.type.ControlType;
 import kr.co.webee.domain.hive.type.GateActionType;
+import kr.co.webee.domain.news.entity.NewsArticle;
+import kr.co.webee.domain.news.entity.NewsArticleKeyword;
 import kr.co.webee.domain.user.entity.User;
 
 import java.time.LocalDate;
@@ -85,6 +87,24 @@ public class TestFixture {
                 .hive(hive)
                 .internalTemperature(25.0)
                 .recordedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static NewsArticle createNewsArticle(String title, String originalLink) {
+        return NewsArticle.builder()
+                .title(title != null ? title : "테스트 뉴스 기사")
+                .summary("테스트 요약")
+                .originalLink(originalLink != null ? originalLink : "https://news.example.com/test")
+                .source("테스트 언론사")
+                .publishedAt(LocalDateTime.of(2026, 6, 16, 9, 0))
+                .fetchedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static NewsArticleKeyword createNewsArticleKeyword(NewsArticle article, String keyword) {
+        return NewsArticleKeyword.builder()
+                .newsArticle(article)
+                .keyword(keyword != null ? keyword : "꿀벌")
                 .build();
     }
 }


### PR DESCRIPTION
## 🧷 이슈

- close #176

## 🔨 작업 내용

- 네이버 뉴스 API 연동 및 수집 스케줄러
  - NewsArticle, NewsArticleKeyword 엔티티 및 Flyway 마이그레이션 생성 (3f7df9f)
  - 네이버 뉴스 API 클라이언트 구현 (HTML 제거, 날짜 파싱 포함) (519dd83)
  - 뉴스 수집 서비스 및 6시간 주기 스케줄러 구현 (기본 키워드 4종 + 사용자 관심 키워드) (d40cb09)
- 뉴스 목록 및 상세 조회 API
  - 뉴스 목록 및 상세 조회 API 및 Swagger 인터페이스 구현 (2d5fbff)
- 테스트 코드
  - NewsService, NewsController, NewsArticleRepository 테스트 작성 (8924354)