### PR TITLE
feat: 관심 농약 API 구현

### DIFF
--- a/src/main/java/kr/co/webee/application/interestpesticide/service/InterestPesticideService.java
+++ b/src/main/java/kr/co/webee/application/interestpesticide/service/InterestPesticideService.java
@@ -1,0 +1,33 @@
+package kr.co.webee.application.interestpesticide.service;
+
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.interestpesticide.entity.InterestPesticide;
+import kr.co.webee.domain.interestpesticide.repository.InterestPesticideRepository;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
+import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InterestPesticideService {
+    private final InterestPesticideRepository interestPesticideRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public InterestPesticideRegisterResponse registerInterestPesticide(InterestPesticideRegisterRequest request, Long userId) {
+        if (interestPesticideRepository.existsByUserIdAndPesticideApplicationNo(userId, request.pesticideApplicationNo())) {
+            throw new BusinessException(ErrorType.INTEREST_PESTICIDE_ALREADY_EXISTS);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorType.USER_NOT_FOUND));
+
+        InterestPesticide interestPesticide = interestPesticideRepository.save(request.toEntity(user));
+        return InterestPesticideRegisterResponse.of(interestPesticide.getId());
+    }
+}

--- a/src/main/java/kr/co/webee/application/interestpesticide/service/InterestPesticideService.java
+++ b/src/main/java/kr/co/webee/application/interestpesticide/service/InterestPesticideService.java
@@ -8,7 +8,10 @@ import kr.co.webee.domain.user.entity.User;
 import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
 import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideListResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,5 +32,11 @@ public class InterestPesticideService {
 
         InterestPesticide interestPesticide = interestPesticideRepository.save(request.toEntity(user));
         return InterestPesticideRegisterResponse.of(interestPesticide.getId());
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<InterestPesticideListResponse> getAllInterestPesticides(Long userId, Pageable pageable) {
+        return interestPesticideRepository.findByUserId(userId, pageable)
+                .map(InterestPesticideListResponse::from);
     }
 }

--- a/src/main/java/kr/co/webee/application/interestpesticide/service/InterestPesticideService.java
+++ b/src/main/java/kr/co/webee/application/interestpesticide/service/InterestPesticideService.java
@@ -39,4 +39,12 @@ public class InterestPesticideService {
         return interestPesticideRepository.findByUserId(userId, pageable)
                 .map(InterestPesticideListResponse::from);
     }
+
+    @Transactional
+    public void removeInterestPesticide(Long interestPesticideId, Long userId) {
+        InterestPesticide entity = interestPesticideRepository.findByIdAndUserId(interestPesticideId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorType.INTEREST_PESTICIDE_NOT_FOUND));
+
+        interestPesticideRepository.delete(entity);
+    }
 }

--- a/src/main/java/kr/co/webee/common/error/ErrorType.java
+++ b/src/main/java/kr/co/webee/common/error/ErrorType.java
@@ -49,6 +49,10 @@ public enum ErrorType {
     INTEREST_MARKET_ALREADY_EXISTS(CONFLICT, DEBUG, "MARKET_001", "이미 등록된 관심 시장입니다"),
     INTEREST_MARKET_NOT_FOUND(NOT_FOUND, DEBUG, "MARKET_002", "등록된 관심 시장을 찾을 수 없습니다"),
 
+    // PesticideErrorType
+    INTEREST_PESTICIDE_ALREADY_EXISTS(CONFLICT, DEBUG, "PESTICIDE_001", "이미 등록된 관심 농약입니다"),
+    INTEREST_PESTICIDE_NOT_FOUND(NOT_FOUND, DEBUG, "PESTICIDE_002", "등록된 관심 농약을 찾을 수 없습니다"),
+
     // FileErrorType
     FILE_UPLOAD_FAILED(BAD_GATEWAY, ERROR, "FILE_001", "파일 업로드에 실패했습니다"),
 

--- a/src/main/java/kr/co/webee/domain/interestpesticide/entity/InterestPesticide.java
+++ b/src/main/java/kr/co/webee/domain/interestpesticide/entity/InterestPesticide.java
@@ -1,0 +1,78 @@
+package kr.co.webee.domain.interestpesticide.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import kr.co.webee.domain.common.BaseTimeEntity;
+import kr.co.webee.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class InterestPesticide extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String pesticideApplicationNo;
+
+    @Column
+    private String brandName;
+
+    @Column
+    private String productName;
+
+    @Column
+    private String contentInfo;
+
+    @Column
+    private String safeSprayInterval;
+
+    @Column
+    private String cropName;
+
+    @Column
+    private String insectName;
+
+    @Column
+    private String usageName;
+
+    @Column
+    private String targetPestName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    private InterestPesticide(String pesticideApplicationNo, String brandName, String productName,
+                              String contentInfo, String safeSprayInterval, String cropName,
+                              String insectName, String usageName, String targetPestName, User user) {
+        if (!StringUtils.hasText(pesticideApplicationNo)) {
+            throw new IllegalArgumentException("pesticideApplicationNo는 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+        this.pesticideApplicationNo = pesticideApplicationNo;
+        this.brandName = brandName;
+        this.productName = productName;
+        this.contentInfo = contentInfo;
+        this.safeSprayInterval = safeSprayInterval;
+        this.cropName = cropName;
+        this.insectName = insectName;
+        this.usageName = usageName;
+        this.targetPestName = targetPestName;
+        this.user = Objects.requireNonNull(user, "user는 null이 될 수 없습니다.");
+    }
+}

--- a/src/main/java/kr/co/webee/domain/interestpesticide/repository/InterestPesticideRepository.java
+++ b/src/main/java/kr/co/webee/domain/interestpesticide/repository/InterestPesticideRepository.java
@@ -1,0 +1,18 @@
+package kr.co.webee.domain.interestpesticide.repository;
+
+import kr.co.webee.domain.interestpesticide.entity.InterestPesticide;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface InterestPesticideRepository extends JpaRepository<InterestPesticide, Long> {
+
+    List<InterestPesticide> findByUserId(Long userId);
+
+    boolean existsByUserIdAndPesticideApplicationNo(Long userId, String pesticideApplicationNo);
+
+    Optional<InterestPesticide> findByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/kr/co/webee/domain/interestpesticide/repository/InterestPesticideRepository.java
+++ b/src/main/java/kr/co/webee/domain/interestpesticide/repository/InterestPesticideRepository.java
@@ -4,13 +4,15 @@ import kr.co.webee.domain.interestpesticide.entity.InterestPesticide;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 @Repository
 public interface InterestPesticideRepository extends JpaRepository<InterestPesticide, Long> {
 
-    List<InterestPesticide> findByUserId(Long userId);
+    Slice<InterestPesticide> findByUserId(Long userId, Pageable pageable);
 
     boolean existsByUserIdAndPesticideApplicationNo(Long userId, String pesticideApplicationNo);
 

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/api/InterestPesticideApi.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/api/InterestPesticideApi.java
@@ -1,0 +1,40 @@
+package kr.co.webee.presentation.interestpesticide.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import kr.co.webee.presentation.support.annotation.ApiDocsErrorType;
+import kr.co.webee.presentation.support.annotation.UserId;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Interest Pesticide", description = "사용자 관심 농약 API")
+public interface InterestPesticideApi {
+
+    @Operation(
+            summary = "관심 농약 등록",
+            description = "농약 등록번호로 관심 농약을 등록합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "등록 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = InterestPesticideRegisterResponse.class)
+                    )
+            ),
+    })
+    @ApiDocsErrorType(ErrorType.INTEREST_PESTICIDE_ALREADY_EXISTS)
+    InterestPesticideRegisterResponse registerInterestPesticide(
+            @RequestBody @Valid InterestPesticideRegisterRequest request,
+            @Parameter(hidden = true) @UserId Long userId
+    );
+}

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/api/InterestPesticideApi.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/api/InterestPesticideApi.java
@@ -11,9 +11,12 @@ import jakarta.validation.Valid;
 import kr.co.webee.common.error.ErrorType;
 import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
 import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideListResponse;
 import kr.co.webee.presentation.support.annotation.ApiDocsErrorType;
 import kr.co.webee.presentation.support.annotation.UserId;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Interest Pesticide", description = "사용자 관심 농약 API")
 public interface InterestPesticideApi {
@@ -36,5 +39,15 @@ public interface InterestPesticideApi {
     InterestPesticideRegisterResponse registerInterestPesticide(
             @RequestBody @Valid InterestPesticideRegisterRequest request,
             @Parameter(hidden = true) @UserId Long userId
+    );
+
+    @Operation(summary = "관심 농약 목록 조회", description = "등록한 관심 농약 목록을 페이지 단위로 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    Slice<InterestPesticideListResponse> getAllInterestPesticides(
+            @Parameter(hidden = true) @UserId Long userId,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size
     );
 }

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/api/InterestPesticideApi.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/api/InterestPesticideApi.java
@@ -15,6 +15,7 @@ import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticide
 import kr.co.webee.presentation.support.annotation.ApiDocsErrorType;
 import kr.co.webee.presentation.support.annotation.UserId;
 import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -49,5 +50,16 @@ public interface InterestPesticideApi {
             @Parameter(hidden = true) @UserId Long userId,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size
+    );
+
+    @Operation(summary = "관심 농약 삭제", description = "등록한 관심 농약을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+    })
+    @ApiDocsErrorType(ErrorType.INTEREST_PESTICIDE_NOT_FOUND)
+    String removeInterestPesticide(
+            @Parameter(description = "관심 농약 등록 ID", example = "1", required = true)
+            @PathVariable Long interestPesticideId,
+            @Parameter(hidden = true) @UserId Long userId
     );
 }

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideController.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideController.java
@@ -1,0 +1,26 @@
+package kr.co.webee.presentation.interestpesticide.controller;
+
+import jakarta.validation.Valid;
+import kr.co.webee.application.interestpesticide.service.InterestPesticideService;
+import kr.co.webee.presentation.interestpesticide.api.InterestPesticideApi;
+import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import kr.co.webee.presentation.support.annotation.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/v1/interest-pesticides")
+@RequiredArgsConstructor
+@RestController
+public class InterestPesticideController implements InterestPesticideApi {
+    private final InterestPesticideService interestPesticideService;
+
+    @Override
+    @PostMapping
+    public InterestPesticideRegisterResponse registerInterestPesticide(
+            @RequestBody @Valid InterestPesticideRegisterRequest request,
+            @UserId Long userId
+    ) {
+        return interestPesticideService.registerInterestPesticide(request, userId);
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideController.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideController.java
@@ -36,4 +36,14 @@ public class InterestPesticideController implements InterestPesticideApi {
     ) {
         return interestPesticideService.getAllInterestPesticides(userId, PageRequest.of(page, size));
     }
+
+    @Override
+    @DeleteMapping("/{interestPesticideId}")
+    public String removeInterestPesticide(
+            @PathVariable Long interestPesticideId,
+            @UserId Long userId
+    ) {
+        interestPesticideService.removeInterestPesticide(interestPesticideId, userId);
+        return "OK";
+    }
 }

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideController.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideController.java
@@ -5,8 +5,11 @@ import kr.co.webee.application.interestpesticide.service.InterestPesticideServic
 import kr.co.webee.presentation.interestpesticide.api.InterestPesticideApi;
 import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
 import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideListResponse;
 import kr.co.webee.presentation.support.annotation.UserId;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/v1/interest-pesticides")
@@ -22,5 +25,15 @@ public class InterestPesticideController implements InterestPesticideApi {
             @UserId Long userId
     ) {
         return interestPesticideService.registerInterestPesticide(request, userId);
+    }
+
+    @Override
+    @GetMapping
+    public Slice<InterestPesticideListResponse> getAllInterestPesticides(
+            @UserId Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return interestPesticideService.getAllInterestPesticides(userId, PageRequest.of(page, size));
     }
 }

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/dto/request/InterestPesticideRegisterRequest.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/dto/request/InterestPesticideRegisterRequest.java
@@ -1,0 +1,54 @@
+package kr.co.webee.presentation.interestpesticide.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import kr.co.webee.domain.interestpesticide.entity.InterestPesticide;
+import kr.co.webee.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "관심 농약 등록 request")
+public record InterestPesticideRegisterRequest(
+        @Schema(description = "농약 등록번호", example = "1-1-000001")
+        @NotBlank
+        String pesticideApplicationNo,
+
+        @Schema(description = "상표명", example = "유기농바이오킬")
+        String brandName,
+
+        @Schema(description = "품목명", example = "비티수화제")
+        String productName,
+
+        @Schema(description = "용량정보", example = "250ml")
+        String contentInfo,
+
+        @Schema(description = "안전사용기준일", example = "3일")
+        String safeSprayInterval,
+
+        @Schema(description = "작물명", example = "벼")
+        String cropName,
+
+        @Schema(description = "해충명", example = "벼멸구")
+        String insectName,
+
+        @Schema(description = "사용방법", example = "경엽처리")
+        String usageName,
+
+        @Schema(description = "적용대상 병해충명", example = "벼멸구, 흰등멸구")
+        String targetPestName
+) {
+    public InterestPesticide toEntity(User user) {
+        return InterestPesticide.builder()
+                .user(user)
+                .pesticideApplicationNo(pesticideApplicationNo)
+                .brandName(brandName)
+                .productName(productName)
+                .contentInfo(contentInfo)
+                .safeSprayInterval(safeSprayInterval)
+                .cropName(cropName)
+                .insectName(insectName)
+                .usageName(usageName)
+                .targetPestName(targetPestName)
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/dto/response/InterestPesticideListResponse.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/dto/response/InterestPesticideListResponse.java
@@ -1,0 +1,54 @@
+package kr.co.webee.presentation.interestpesticide.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.co.webee.domain.interestpesticide.entity.InterestPesticide;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "관심 농약 정보")
+public record InterestPesticideListResponse(
+        @Schema(description = "관심 농약 ID", example = "1")
+        Long interestPesticideId,
+
+        @Schema(description = "농약 등록번호", example = "1-1-000001")
+        String pesticideApplicationNo,
+
+        @Schema(description = "상표명", example = "유기농바이오킬")
+        String brandName,
+
+        @Schema(description = "품목명", example = "비티수화제")
+        String productName,
+
+        @Schema(description = "용량정보", example = "250ml")
+        String contentInfo,
+
+        @Schema(description = "안전사용기준일", example = "3일")
+        String safeSprayInterval,
+
+        @Schema(description = "작물명", example = "벼")
+        String cropName,
+
+        @Schema(description = "해충명", example = "벼멸구")
+        String insectName,
+
+        @Schema(description = "사용방법", example = "경엽처리")
+        String usageName,
+
+        @Schema(description = "적용대상 병해충명", example = "벼멸구, 흰등멸구")
+        String targetPestName
+) {
+    public static InterestPesticideListResponse from(InterestPesticide interestPesticide) {
+        return InterestPesticideListResponse.builder()
+                .interestPesticideId(interestPesticide.getId())
+                .pesticideApplicationNo(interestPesticide.getPesticideApplicationNo())
+                .brandName(interestPesticide.getBrandName())
+                .productName(interestPesticide.getProductName())
+                .contentInfo(interestPesticide.getContentInfo())
+                .safeSprayInterval(interestPesticide.getSafeSprayInterval())
+                .cropName(interestPesticide.getCropName())
+                .insectName(interestPesticide.getInsectName())
+                .usageName(interestPesticide.getUsageName())
+                .targetPestName(interestPesticide.getTargetPestName())
+                .build();
+    }
+}

--- a/src/main/java/kr/co/webee/presentation/interestpesticide/dto/response/InterestPesticideRegisterResponse.java
+++ b/src/main/java/kr/co/webee/presentation/interestpesticide/dto/response/InterestPesticideRegisterResponse.java
@@ -1,0 +1,17 @@
+package kr.co.webee.presentation.interestpesticide.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "관심 농약 등록 response")
+public record InterestPesticideRegisterResponse(
+        @Schema(description = "관심 농약 ID", example = "1")
+        Long interestPesticideId
+) {
+    public static InterestPesticideRegisterResponse of(Long interestPesticideId) {
+        return InterestPesticideRegisterResponse.builder()
+                .interestPesticideId(interestPesticideId)
+                .build();
+    }
+}

--- a/src/main/resources/db/migration/V4__create_interest_pesticide.sql
+++ b/src/main/resources/db/migration/V4__create_interest_pesticide.sql
@@ -1,0 +1,19 @@
+CREATE TABLE interest_pesticide
+(
+    id                        BIGINT       NOT NULL AUTO_INCREMENT,
+    user_id                   BIGINT       NOT NULL,
+    pesticide_application_no  VARCHAR(20)  NOT NULL,
+    brand_name                VARCHAR(100),
+    product_name              VARCHAR(100),
+    content_info              VARCHAR(50),
+    safe_spray_interval       VARCHAR(50),
+    crop_name                 VARCHAR(50),
+    insect_name               VARCHAR(50),
+    usage_name                VARCHAR(50),
+    target_pest_name          VARCHAR(200),
+    created_at                DATETIME     NOT NULL,
+    modified_at               DATETIME     NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_interest_pesticide (user_id, pesticide_application_no),
+    CONSTRAINT fk_interest_pesticide_user FOREIGN KEY (user_id) REFERENCES user (id)
+);

--- a/src/test/java/kr/co/webee/application/interestpesticide/service/InterestPesticideServiceTest.java
+++ b/src/test/java/kr/co/webee/application/interestpesticide/service/InterestPesticideServiceTest.java
@@ -8,12 +8,15 @@ import kr.co.webee.domain.user.entity.User;
 import kr.co.webee.domain.user.repository.UserRepository;
 import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
 import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideListResponse;
 import kr.co.webee.support.util.TestFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -94,6 +97,73 @@ class InterestPesticideServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .extracting("type")
                     .isEqualTo(ErrorType.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("관심 농약 목록 조회")
+    class GetAllInterestPesticides {
+
+        @Test
+        @DisplayName("등록한 관심 농약 목록을 조회한다.")
+        void getAllInterestPesticides() {
+            //given
+            interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000001")
+                            .cropName("딸기")
+                            .build(),
+                    user.getId());
+            interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000002")
+                            .cropName("벼")
+                            .build(),
+                    user.getId());
+
+            //when
+            Slice<InterestPesticideListResponse> result = interestPesticideService.getAllInterestPesticides(
+                    user.getId(), PageRequest.of(0, 10));
+
+            //then
+            assertThat(result.getContent()).hasSize(2)
+                    .extracting("pesticideApplicationNo")
+                    .containsExactlyInAnyOrder("1-1-000001", "1-1-000002");
+        }
+
+        @Test
+        @DisplayName("등록한 관심 농약이 없으면 빈 목록을 반환한다.")
+        void getAllInterestPesticides_empty() {
+            //when
+            Slice<InterestPesticideListResponse> result = interestPesticideService.getAllInterestPesticides(
+                    user.getId(), PageRequest.of(0, 10));
+
+            //then
+            assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("페이지 크기보다 많으면 hasNext가 true다.")
+        void getAllInterestPesticides_hasNext() {
+            //given
+            interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000001")
+                            .build(),
+                    user.getId());
+            interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000002")
+                            .build(),
+                    user.getId());
+
+            //when
+            Slice<InterestPesticideListResponse> result = interestPesticideService.getAllInterestPesticides(
+                    user.getId(), PageRequest.of(0, 1));
+
+            //then
+            assertThat(result.hasNext()).isTrue();
+            assertThat(result.getContent()).hasSize(1);
         }
     }
 }

--- a/src/test/java/kr/co/webee/application/interestpesticide/service/InterestPesticideServiceTest.java
+++ b/src/test/java/kr/co/webee/application/interestpesticide/service/InterestPesticideServiceTest.java
@@ -1,0 +1,99 @@
+package kr.co.webee.application.interestpesticide.service;
+
+import kr.co.webee.annotation.IntegrationTest;
+import kr.co.webee.common.error.ErrorType;
+import kr.co.webee.common.error.exception.BusinessException;
+import kr.co.webee.domain.interestpesticide.repository.InterestPesticideRepository;
+import kr.co.webee.domain.user.entity.User;
+import kr.co.webee.domain.user.repository.UserRepository;
+import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IntegrationTest
+class InterestPesticideServiceTest {
+
+    @Autowired
+    private InterestPesticideService interestPesticideService;
+
+    @Autowired
+    private InterestPesticideRepository interestPesticideRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        interestPesticideRepository.deleteAllInBatch();
+        user = userRepository.save(TestFixture.createUser("pesticide-user"));
+    }
+
+    @Nested
+    @DisplayName("관심 농약 등록")
+    class RegisterInterestPesticide {
+
+        @Test
+        @DisplayName("관심 농약을 등록한다.")
+        void registerInterestPesticide() {
+            //given
+            InterestPesticideRegisterRequest request = InterestPesticideRegisterRequest.builder()
+                    .pesticideApplicationNo("1-1-000001")
+                    .brandName("유기농바이오킬")
+                    .productName("비티수화제")
+                    .cropName("벼")
+                    .build();
+
+            //when
+            InterestPesticideRegisterResponse response = interestPesticideService.registerInterestPesticide(request, user.getId());
+
+            //then
+            assertThat(response.interestPesticideId()).isNotNull();
+            assertThat(interestPesticideRepository.count()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("이미 등록된 농약을 다시 등록하면 예외가 발생한다.")
+        void registerInterestPesticide_duplicate() {
+            //given
+            interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000001")
+                            .build(),
+                    user.getId());
+
+            //when - then
+            assertThatThrownBy(() -> interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000001")
+                            .build(),
+                    user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.INTEREST_PESTICIDE_ALREADY_EXISTS);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자로 등록하면 예외가 발생한다.")
+        void registerInterestPesticide_userNotFound() {
+            //when - then
+            assertThatThrownBy(() -> interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000001")
+                            .build(),
+                    -1L))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.USER_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/application/interestpesticide/service/InterestPesticideServiceTest.java
+++ b/src/test/java/kr/co/webee/application/interestpesticide/service/InterestPesticideServiceTest.java
@@ -166,4 +166,54 @@ class InterestPesticideServiceTest {
             assertThat(result.getContent()).hasSize(1);
         }
     }
+
+    @Nested
+    @DisplayName("관심 농약 삭제")
+    class RemoveInterestPesticide {
+
+        @Test
+        @DisplayName("관심 농약을 삭제한다.")
+        void removeInterestPesticide() {
+            //given
+            Long id = interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000001")
+                            .build(),
+                    user.getId()).interestPesticideId();
+
+            //when
+            interestPesticideService.removeInterestPesticide(id, user.getId());
+
+            //then
+            assertThat(interestPesticideRepository.count()).isZero();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 관심 농약을 삭제하면 예외가 발생한다.")
+        void removeInterestPesticide_notFound() {
+            //when - then
+            assertThatThrownBy(() -> interestPesticideService.removeInterestPesticide(-1L, user.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.INTEREST_PESTICIDE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 관심 농약을 삭제하면 예외가 발생한다.")
+        void removeInterestPesticide_otherUser() {
+            //given
+            Long id = interestPesticideService.registerInterestPesticide(
+                    InterestPesticideRegisterRequest.builder()
+                            .pesticideApplicationNo("1-1-000001")
+                            .build(),
+                    user.getId()).interestPesticideId();
+            User otherUser = userRepository.save(TestFixture.createUser("other-user"));
+
+            //when - then
+            assertThatThrownBy(() -> interestPesticideService.removeInterestPesticide(id, otherUser.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("type")
+                    .isEqualTo(ErrorType.INTEREST_PESTICIDE_NOT_FOUND);
+        }
+    }
 }

--- a/src/test/java/kr/co/webee/application/news/service/NewsCollectServiceTest.java
+++ b/src/test/java/kr/co/webee/application/news/service/NewsCollectServiceTest.java
@@ -45,22 +45,16 @@ class NewsCollectServiceTest {
     @DisplayName("뉴스 기사 수집")
     class CollectNewsArticles {
 
-        private final NaverNewsResponse emptyResponse = new NaverNewsResponse(0, 0, List.of());
-
-        private NaverNewsResponse singleItemResponse(String title, String originalLink) {
-            return new NaverNewsResponse(1, 1, List.of(
-                    new NaverNewsResponse.Item(title, "테스트 요약", originalLink, originalLink,
-                            "Tue, 16 Jun 2026 09:00:00 +0900")
-            ));
-        }
-
         @Test
         @DisplayName("기본 키워드에 해당하는 기사를 수집하여 저장한다.")
         void collectNewsArticles_savesArticlesForDefaultKeywords() {
             //given
-            when(newsClient.fetchNews(anyString())).thenReturn(emptyResponse);
-            when(newsClient.fetchNews(eq("꿀벌"))).thenReturn(
-                    singleItemResponse("꿀벌 기사", "https://news.example.com/1"));
+            when(newsClient.fetchNews(anyString())).thenReturn(new NaverNewsResponse(0, 0, List.of()));
+            when(newsClient.fetchNews(eq("꿀벌"))).thenReturn(new NaverNewsResponse(1, 1, List.of(
+                    new NaverNewsResponse.Item("꿀벌 기사", "테스트 요약",
+                            "https://news.example.com/1", "https://news.example.com/1",
+                            "Tue, 16 Jun 2026 09:00:00 +0900")
+            )));
 
             //when
             newsCollectService.collectNewsArticles();
@@ -74,7 +68,7 @@ class NewsCollectServiceTest {
         @DisplayName("빈 응답이면 기사를 저장하지 않는다.")
         void collectNewsArticles_emptyResponse() {
             //given
-            when(newsClient.fetchNews(anyString())).thenReturn(emptyResponse);
+            when(newsClient.fetchNews(anyString())).thenReturn(new NaverNewsResponse(0, 0, List.of()));
 
             //when
             newsCollectService.collectNewsArticles();

--- a/src/test/java/kr/co/webee/application/news/service/NewsServiceTest.java
+++ b/src/test/java/kr/co/webee/application/news/service/NewsServiceTest.java
@@ -111,17 +111,14 @@ class NewsServiceTest {
     @DisplayName("키워드별 뉴스 기사 저장")
     class AddNewsArticleByKeyword {
 
-        private List<NaverNewsResponse.Item> singleItem(String title, String originalLink) {
-            return List.of(new NaverNewsResponse.Item(
-                    title, "테스트 요약", originalLink, originalLink,
-                    "Tue, 16 Jun 2026 09:00:00 +0900"));
-        }
-
         @Test
         @DisplayName("새로운 기사이면 저장한다.")
         void addNewsArticleByKeyword_savesNewArticle() {
             //when
-            newsService.addNewsArticleByKeyword("꿀벌", singleItem("꿀벌 기사", "https://news.example.com/1"));
+            newsService.addNewsArticleByKeyword("꿀벌", List.of(
+                    new NaverNewsResponse.Item("꿀벌 기사", "테스트 요약",
+                            "https://news.example.com/1", "https://news.example.com/1",
+                            "Tue, 16 Jun 2026 09:00:00 +0900")));
 
             //then
             assertThat(newsArticleRepository.count()).isEqualTo(1);
@@ -137,7 +134,10 @@ class NewsServiceTest {
             newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article, "꿀벌"));
 
             //when
-            newsService.addNewsArticleByKeyword("양봉", singleItem("꿀벌 기사", "https://news.example.com/1"));
+            newsService.addNewsArticleByKeyword("양봉", List.of(
+                    new NaverNewsResponse.Item("꿀벌 기사", "테스트 요약",
+                            "https://news.example.com/1", "https://news.example.com/1",
+                            "Tue, 16 Jun 2026 09:00:00 +0900")));
 
             //then
             assertThat(newsArticleRepository.count()).isEqualTo(1);
@@ -153,7 +153,10 @@ class NewsServiceTest {
             newsArticleKeywordRepository.save(TestFixture.createNewsArticleKeyword(article, "꿀벌"));
 
             //when
-            newsService.addNewsArticleByKeyword("꿀벌", singleItem("꿀벌 기사", "https://news.example.com/1"));
+            newsService.addNewsArticleByKeyword("꿀벌", List.of(
+                    new NaverNewsResponse.Item("꿀벌 기사", "테스트 요약",
+                            "https://news.example.com/1", "https://news.example.com/1",
+                            "Tue, 16 Jun 2026 09:00:00 +0900")));
 
             //then
             assertThat(newsArticleKeywordRepository.count()).isEqualTo(1);

--- a/src/test/java/kr/co/webee/domain/interestpesticide/entity/InterestPesticideTest.java
+++ b/src/test/java/kr/co/webee/domain/interestpesticide/entity/InterestPesticideTest.java
@@ -1,0 +1,37 @@
+package kr.co.webee.domain.interestpesticide.entity;
+
+import kr.co.webee.support.util.TestFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InterestPesticideTest {
+
+    @Test
+    @DisplayName("관심 농약을 생성한다.")
+    void createInterestPesticide() {
+        //when
+        InterestPesticide interestPesticide = InterestPesticide.builder()
+                .user(TestFixture.createUser(null))
+                .pesticideApplicationNo("1-1-000001")
+                .brandName("유기농바이오킬")
+                .build();
+
+        //then
+        assertThat(interestPesticide.getPesticideApplicationNo()).isEqualTo("1-1-000001");
+        assertThat(interestPesticide.getBrandName()).isEqualTo("유기농바이오킬");
+    }
+
+    @Test
+    @DisplayName("pesticideApplicationNo가 빈 값이면 예외가 발생한다.")
+    void createInterestPesticide_blankApplicationNo() {
+        //when - then
+        assertThatThrownBy(() -> InterestPesticide.builder()
+                .user(TestFixture.createUser(null))
+                .pesticideApplicationNo("")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideControllerTest.java
@@ -1,0 +1,90 @@
+package kr.co.webee.presentation.interestpesticide.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.webee.application.interestpesticide.service.InterestPesticideService;
+import kr.co.webee.config.TestWebConfig;
+import kr.co.webee.presentation.config.WebConfig;
+import kr.co.webee.presentation.interestpesticide.dto.request.InterestPesticideRegisterRequest;
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideRegisterResponse;
+import kr.co.webee.presentation.support.resolver.UserIdArgumentResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = InterestPesticideController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OncePerRequestFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UserIdArgumentResolver.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)
+        }
+)
+@Import(TestWebConfig.class)
+@ActiveProfiles("test")
+class InterestPesticideControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private InterestPesticideService interestPesticideService;
+
+    @Test
+    @DisplayName("관심 농약을 등록한다.")
+    void registerInterestPesticide() throws Exception {
+        //given
+        InterestPesticideRegisterRequest request = InterestPesticideRegisterRequest.builder()
+                .pesticideApplicationNo("1-1-000001")
+                .brandName("유기농바이오킬")
+                .cropName("벼")
+                .build();
+        when(interestPesticideService.registerInterestPesticide(any(), any()))
+                .thenReturn(InterestPesticideRegisterResponse.of(1L));
+
+        //when - then
+        mockMvc.perform(post("/api/v1/interest-pesticides")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                .andExpect(jsonPath("$.data.interestPesticideId").value(1))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("pesticideApplicationNo가 없으면 400이 반환된다.")
+    void registerInterestPesticide_missingApplicationNo() throws Exception {
+        //given
+        InterestPesticideRegisterRequest request = InterestPesticideRegisterRequest.builder()
+                .pesticideApplicationNo("")
+                .build();
+
+        //when - then
+        mockMvc.perform(post("/api/v1/interest-pesticides")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+}

--- a/src/test/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideControllerTest.java
@@ -29,9 +29,9 @@ import org.springframework.data.domain.SliceImpl;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -145,6 +145,22 @@ class InterestPesticideControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.content").isArray())
                     .andExpect(jsonPath("$.data.content.length()").value(0))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("관심 농약 삭제")
+    class RemoveInterestPesticide {
+
+        @Test
+        @DisplayName("관심 농약을 삭제한다.")
+        void removeInterestPesticide() throws Exception {
+            //when - then
+            mockMvc.perform(delete("/api/v1/interest-pesticides/{interestPesticideId}", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data").value("OK"))
                     .andDo(print());
         }
     }

--- a/src/test/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/interestpesticide/controller/InterestPesticideControllerTest.java
@@ -21,8 +21,18 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import kr.co.webee.presentation.interestpesticide.dto.response.InterestPesticideListResponse;
+import org.junit.jupiter.api.Nested;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -86,5 +96,56 @@ class InterestPesticideControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andDo(print());
+    }
+
+    @Nested
+    @DisplayName("관심 농약 목록 조회")
+    class GetAllInterestPesticides {
+
+        @Test
+        @DisplayName("관심 농약 목록을 조회한다.")
+        void getAllInterestPesticides() throws Exception {
+            //given
+            List<InterestPesticideListResponse> items = List.of(
+                    InterestPesticideListResponse.builder()
+                            .interestPesticideId(1L)
+                            .pesticideApplicationNo("1-1-000001")
+                            .cropName("딸기")
+                            .build(),
+                    InterestPesticideListResponse.builder()
+                            .interestPesticideId(2L)
+                            .pesticideApplicationNo("1-1-000002")
+                            .cropName("벼")
+                            .build()
+            );
+            when(interestPesticideService.getAllInterestPesticides(anyLong(), any()))
+                    .thenReturn(new SliceImpl<>(items, PageRequest.of(0, 10), false));
+
+            //when - then
+            mockMvc.perform(get("/api/v1/interest-pesticides")
+                            .param("page", "0")
+                            .param("size", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(2))
+                    .andExpect(jsonPath("$.data.content[0].pesticideApplicationNo").value("1-1-000001"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("등록된 관심 농약이 없으면 빈 배열을 반환한다.")
+        void getAllInterestPesticides_empty() throws Exception {
+            //given
+            when(interestPesticideService.getAllInterestPesticides(anyLong(), any()))
+                    .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 10), false));
+
+            //when - then
+            mockMvc.perform(get("/api/v1/interest-pesticides"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").isArray())
+                    .andExpect(jsonPath("$.data.content.length()").value(0))
+                    .andDo(print());
+        }
     }
 }


### PR DESCRIPTION
## 🧷 이슈

- close #178

## 🔨 작업 내용

- InterestPesticide 엔티티 생성 및 Flyway 마이그레이션 (6639c97)
- 관심 농약 저장 API 구현 (9090ae7)
- 관심 농약 목록 조회 API 구현 (3f00952)
- 관심 농약 삭제 API 구현 (5ccaac5)