### PR TITLE
fix: AI 챗봇 응답에 참고 문서 출처 추가

### DIFF
--- a/src/main/java/kr/co/webee/application/ai/AssistantService.java
+++ b/src/main/java/kr/co/webee/application/ai/AssistantService.java
@@ -4,6 +4,7 @@ import kr.co.webee.infrastructure.ai.AiPromptExecutor;
 import kr.co.webee.presentation.ai.chat.dto.AssistantResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
@@ -11,7 +12,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
+
+import static org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor.*;
 
 @Service
 @RequiredArgsConstructor
@@ -28,20 +32,32 @@ public class AssistantService {
 
     public AssistantResponse answerUserInput(String input, String conversationId) {
         String convId = StringUtils.isBlank(conversationId) ? UUID.randomUUID().toString() : conversationId;
+
         RagSearchOptions ragOptions = new RagSearchOptions(
                 "type != 'faq' AND type != 'guide'",
                 topK,
                 similarityThreshold
         );
 
-        String result = aiPromptExecutor.run(input, builder ->
+        ChatResponse chatResponse = aiPromptExecutor.run(input, builder ->
                 builder.input(input)
                         .withLogger()
                         .withMemory(convId)
                         .withRag("assistant-prompt", ragOptions)
         );
 
-        return new AssistantResponse(result, conversationId);
+        String answer = chatResponse.getResult().getOutput().getText();
+
+        List<Document> retrievedDocs = (List<Document>) chatResponse.getMetadata()
+                .get(RETRIEVED_DOCUMENTS);
+
+        List<String> sources = retrievedDocs == null ? List.of() : retrievedDocs.stream()
+                .map(doc -> (String) doc.getMetadata().get("origin"))
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        return new AssistantResponse(answer, convId, sources);
     }
 
     public List<String> getBeeFaqQuestions() {

--- a/src/main/java/kr/co/webee/infrastructure/ai/AiPromptExecutor.java
+++ b/src/main/java/kr/co/webee/infrastructure/ai/AiPromptExecutor.java
@@ -5,6 +5,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.client.advisor.SimpleLoggerAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
@@ -22,10 +23,10 @@ public class AiPromptExecutor {
     private final SimpleLoggerAdvisor loggerAdvisor;
     private final MessageChatMemoryAdvisor memoryAdvisor;
 
-    public String run(String input, Consumer<AdvisorBuilder.Builder> config) {
+    public ChatResponse run(String input, Consumer<AdvisorBuilder.Builder> config) {
         var builder = AdvisorBuilder.builder(vectorStore, promptRegistry, loggerAdvisor, memoryAdvisor);
         config.accept(builder);
-        return buildRequest(input, builder).call().content();
+        return buildRequest(input, builder).call().chatResponse();
     }
 
     public <T> T run(String input, Consumer<AdvisorBuilder.Builder> config, Class<T> clazz) {

--- a/src/main/java/kr/co/webee/presentation/ai/chat/dto/AssistantResponse.java
+++ b/src/main/java/kr/co/webee/presentation/ai/chat/dto/AssistantResponse.java
@@ -2,6 +2,8 @@ package kr.co.webee.presentation.ai.chat.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 @Schema(description = "AI 응답 결과 객체")
 public record AssistantResponse(
 
@@ -9,6 +11,9 @@ public record AssistantResponse(
         String answer,
 
         @Schema(description = "대화 식별자 (세션 ID)", example = "8a12f9c1-54a3-4d8f-b2c2-017fa38a7763")
-        String conversationId
+        String conversationId,
+
+        @Schema(description = "답변 생성에 참고한 문서 출처 목록", example = "[\"농촌진흥청 양봉 매뉴얼\", \"국립농업과학원 수정벌 가이드\"]")
+        List<String> sources
 ) {
 }

--- a/src/test/java/kr/co/webee/application/ai/AssistantServiceTest.java
+++ b/src/test/java/kr/co/webee/application/ai/AssistantServiceTest.java
@@ -1,0 +1,189 @@
+package kr.co.webee.application.ai;
+
+import kr.co.webee.annotation.IntegrationTest;
+import kr.co.webee.infrastructure.ai.AiPromptExecutor;
+import kr.co.webee.presentation.ai.chat.dto.AssistantResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.springframework.ai.vectorstore.SearchRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS;
+
+@IntegrationTest
+class AssistantServiceTest {
+
+    @Autowired
+    private AssistantService assistantService;
+
+    @MockitoBean
+    private AiPromptExecutor aiPromptExecutor;
+
+    @MockitoBean
+    private VectorStore vectorStore;
+
+    @Nested
+    @DisplayName("AI 답변 생성")
+    class AnswerUserInput {
+
+        @Test
+        @DisplayName("출처가 있는 경우 sources에 포함된다.")
+        void answerUserInput_withSources() {
+            //given
+            Document doc1 = new Document("내용1", Map.of("origin", "농촌진흥청 양봉 매뉴얼"));
+            Document doc2 = new Document("내용2", Map.of("origin", "국립농업과학원 수정벌 가이드"));
+            ChatResponse chatResponse = mockChatResponse("AI 답변", List.of(doc1, doc2));
+            when(aiPromptExecutor.run(any(), any())).thenReturn(chatResponse);
+
+            //when
+            AssistantResponse response = assistantService.answerUserInput("질문", "conv-id");
+
+            //then
+            assertThat(response.answer()).isEqualTo("AI 답변");
+            assertThat(response.sources()).containsExactlyInAnyOrder(
+                    "농촌진흥청 양봉 매뉴얼",
+                    "국립농업과학원 수정벌 가이드"
+            );
+        }
+
+        @Test
+        @DisplayName("참고 문서가 없으면 sources는 빈 목록이다.")
+        void answerUserInput_noSources() {
+            //given
+            ChatResponse chatResponse = mockChatResponse("AI 답변", null);
+            when(aiPromptExecutor.run(any(), any())).thenReturn(chatResponse);
+
+            //when
+            AssistantResponse response = assistantService.answerUserInput("질문", "conv-id");
+
+            //then
+            assertThat(response.sources()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("origin이 없는 문서는 sources에서 제외된다.")
+        void answerUserInput_filterNullOrigin() {
+            //given
+            Document docWithOrigin = new Document("내용1", Map.of("origin", "농촌진흥청 양봉 매뉴얼"));
+            Document docWithoutOrigin = new Document("내용2", Map.of());
+            ChatResponse chatResponse = mockChatResponse("AI 답변", List.of(docWithOrigin, docWithoutOrigin));
+            when(aiPromptExecutor.run(any(), any())).thenReturn(chatResponse);
+
+            //when
+            AssistantResponse response = assistantService.answerUserInput("질문", "conv-id");
+
+            //then
+            assertThat(response.sources()).containsExactly("농촌진흥청 양봉 매뉴얼");
+        }
+
+        @Test
+        @DisplayName("중복된 출처는 하나만 포함된다.")
+        void answerUserInput_distinctSources() {
+            //given
+            Document doc1 = new Document("내용1", Map.of("origin", "농촌진흥청 양봉 매뉴얼"));
+            Document doc2 = new Document("내용2", Map.of("origin", "농촌진흥청 양봉 매뉴얼"));
+            ChatResponse chatResponse = mockChatResponse("AI 답변", List.of(doc1, doc2));
+            when(aiPromptExecutor.run(any(), any())).thenReturn(chatResponse);
+
+            //when
+            AssistantResponse response = assistantService.answerUserInput("질문", "conv-id");
+
+            //then
+            assertThat(response.sources()).hasSize(1)
+                    .containsExactly("농촌진흥청 양봉 매뉴얼");
+        }
+
+        @Test
+        @DisplayName("conversationId가 비어있으면 새 UUID를 생성한다.")
+        void answerUserInput_blankConversationId() {
+            //given
+            ChatResponse chatResponse = mockChatResponse("AI 답변", null);
+            when(aiPromptExecutor.run(any(), any())).thenReturn(chatResponse);
+
+            //when
+            AssistantResponse response = assistantService.answerUserInput("질문", "");
+
+            //then
+            assertThat(response.conversationId()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("conversationId가 있으면 그대로 반환한다.")
+        void answerUserInput_existingConversationId() {
+            //given
+            String conversationId = "existing-conv-id";
+            ChatResponse chatResponse = mockChatResponse("AI 답변", null);
+            when(aiPromptExecutor.run(any(), any())).thenReturn(chatResponse);
+
+            //when
+            AssistantResponse response = assistantService.answerUserInput("질문", conversationId);
+
+            //then
+            assertThat(response.conversationId()).isEqualTo(conversationId);
+        }
+
+        private ChatResponse mockChatResponse(String answer, List<Document> retrievedDocs) {
+            ChatResponse chatResponse = mock(ChatResponse.class);
+            Generation generation = mock(Generation.class);
+            AssistantMessage assistantMessage = mock(AssistantMessage.class);
+            ChatResponseMetadata metadata = mock(ChatResponseMetadata.class);
+
+            when(chatResponse.getResult()).thenReturn(generation);
+            when(generation.getOutput()).thenReturn(assistantMessage);
+            when(assistantMessage.getText()).thenReturn(answer);
+            when(chatResponse.getMetadata()).thenReturn(metadata);
+            when(metadata.get(RETRIEVED_DOCUMENTS)).thenReturn(retrievedDocs);
+
+            return chatResponse;
+        }
+    }
+
+    @Nested
+    @DisplayName("꿀벌 FAQ 질문 조회")
+    class GetBeeFaqQuestions {
+
+        @Test
+        @DisplayName("FAQ 문서가 있으면 텍스트 목록을 반환한다.")
+        void getBeeFaqQuestions_withDocs() {
+            //given
+            Document doc1 = new Document("꿀벌 FAQ 질문1");
+            Document doc2 = new Document("꿀벌 FAQ 질문2");
+            when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of(doc1, doc2));
+
+            //when
+            List<String> result = assistantService.getBeeFaqQuestions();
+
+            //then
+            assertThat(result).containsExactly("꿀벌 FAQ 질문1", "꿀벌 FAQ 질문2");
+        }
+
+        @Test
+        @DisplayName("FAQ 문서가 없으면 빈 목록을 반환한다.")
+        void getBeeFaqQuestions_empty() {
+            //given
+            when(vectorStore.similaritySearch(any(SearchRequest.class))).thenReturn(List.of());
+
+            //when
+            List<String> result = assistantService.getBeeFaqQuestions();
+
+            //then
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/src/test/java/kr/co/webee/presentation/ai/chat/controller/AssistantControllerTest.java
+++ b/src/test/java/kr/co/webee/presentation/ai/chat/controller/AssistantControllerTest.java
@@ -1,0 +1,106 @@
+package kr.co.webee.presentation.ai.chat.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.webee.application.ai.AssistantService;
+import kr.co.webee.config.TestWebConfig;
+import kr.co.webee.presentation.ai.chat.dto.AssistantRequest;
+import kr.co.webee.presentation.ai.chat.dto.AssistantResponse;
+import kr.co.webee.presentation.config.WebConfig;
+import kr.co.webee.presentation.support.resolver.UserIdArgumentResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(TestWebConfig.class)
+@WebMvcTest(
+        controllers = AssistantController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OncePerRequestFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = UserIdArgumentResolver.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebConfig.class)
+        }
+)
+@ActiveProfiles("test")
+class AssistantControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AssistantService assistantService;
+
+    @Nested
+    @DisplayName("AI 질문 응답 생성")
+    class AnswerUserInput {
+
+        @Test
+        @DisplayName("질문에 대한 AI 답변과 출처를 반환한다.")
+        void answerUserInput() throws Exception {
+            //given
+            AssistantRequest request = new AssistantRequest("호박벌은 어디에 쓰이죠?", "conv-id", null);
+            AssistantResponse response = new AssistantResponse(
+                    "호박벌은 온실 작물의 수정에 사용됩니다.",
+                    "conv-id",
+                    List.of("농촌진흥청 양봉 매뉴얼", "국립농업과학원 수정벌 가이드")
+            );
+            when(assistantService.answerUserInput(anyString(), anyString())).thenReturn(response);
+
+            //when - then
+            mockMvc.perform(post("/api/v1/assistants/messages")
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+                    .andExpect(jsonPath("$.data.answer").value("호박벌은 온실 작물의 수정에 사용됩니다."))
+                    .andExpect(jsonPath("$.data.conversationId").value("conv-id"))
+                    .andExpect(jsonPath("$.data.sources").isArray())
+                    .andExpect(jsonPath("$.data.sources.length()").value(2))
+                    .andExpect(jsonPath("$.data.sources[0]").value("농촌진흥청 양봉 매뉴얼"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("출처가 없는 경우 빈 목록을 반환한다.")
+        void answerUserInput_emptySources() throws Exception {
+            //given
+            AssistantRequest request = new AssistantRequest("질문", null, null);
+            AssistantResponse response = new AssistantResponse("답변", "new-conv-id", List.of());
+            when(assistantService.answerUserInput(anyString(), any())).thenReturn(response);
+
+            //when - then
+            mockMvc.perform(post("/api/v1/assistants/messages")
+                            .content(objectMapper.writeValueAsString(request))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.sources").isArray())
+                    .andExpect(jsonPath("$.data.sources.length()").value(0))
+                    .andDo(print());
+        }
+    }
+
+}


### PR DESCRIPTION
## 🧷 이슈

- close #

## 🔨 작업 내용

- AI 챗봇 응답에 참고 문서 출처(sources) 추가
  - AssistantResponse에 sources 필드 추가 및 벡터 DB 검색 결과에서 origin 추출 (0e962fe)
- 테스트 코드 추가
  - AssistantService 테스트 추가 - sources 추출 로직 및 conversationId 처리 검증 (11b56a0)
  - AssistantController 테스트 추가 - sources 포함 응답 직렬화 검증 (11b56a0)