### PR TITLE
fix: AI 챗봇 RAG 필터 표현식 수정

### DIFF
--- a/src/main/java/kr/co/webee/application/ai/AssistantService.java
+++ b/src/main/java/kr/co/webee/application/ai/AssistantService.java
@@ -34,7 +34,7 @@ public class AssistantService {
         String convId = StringUtils.isBlank(conversationId) ? UUID.randomUUID().toString() : conversationId;
 
         RagSearchOptions ragOptions = new RagSearchOptions(
-                "type != 'faq' AND type != 'guide'",
+                "category == 'bee'",
                 topK,
                 similarityThreshold
         );


### PR DESCRIPTION
## 🧷 이슈

- close #

## 🔨 작업 내용

- AI 챗봇 RAG 필터 표현식 수정
  - 벡터 검색 필터 조건을 `type != 'faq' AND type != 'guide'`에서 `category == 'bee'`로 교체 (46dc1e7)
    - 기존 필터는 faq·guide 타입 청크를 검색 대상에서 제외해, 사용자 질문에 직접 대응하는 유용한 청크가 누락되는 문제가 있었음
    - `type`은 콘텐츠 성격(fact/guide/faq) 분류이므로 검색 범위 제한 기준으로 부적절하며, 도메인 단위인 `category`로 필터링하는 것이 의도에 맞음