### PR TITLE
fix: hive/+/# 구독 시 서버 발행 control 토픽 수신으로 예외 발생하는 문제 수정

### DIFF
--- a/src/main/java/kr/co/webee/application/mqtt/MqttMessageDispatcher.java
+++ b/src/main/java/kr/co/webee/application/mqtt/MqttMessageDispatcher.java
@@ -31,10 +31,16 @@ public class MqttMessageDispatcher implements MessageHandler {
     }
 
     private void dispatch(String topic, String macAddress, Object payload) {
-        MqttMessageHandler handler = handlerMap.get(MqttTopicType.from(topic));
+        MqttTopicType topicType = MqttTopicType.from(topic);
+        if (topicType == null) {
+            log.debug("처리하지 않는 MQTT 토픽 무시: {}", topic);
+            return;
+        }
 
+        MqttMessageHandler handler = handlerMap.get(topicType);
         if (handler == null) {
-            throw new IllegalStateException("topic: %s에 대한 handler가 존재하지 않습니다.".formatted(topic));
+            log.warn("topic: {}에 대한 handler가 존재하지 않습니다.", topic);
+            return;
         }
 
         handler.handle(payload, macAddress);

--- a/src/main/java/kr/co/webee/application/mqtt/MqttTopicType.java
+++ b/src/main/java/kr/co/webee/application/mqtt/MqttTopicType.java
@@ -20,7 +20,7 @@ public enum MqttTopicType {
         return Arrays.stream(values())
                 .filter(type -> type.matches(topic))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("topic: %s이 존재하지 않습니다.".formatted(topic)));
+                .orElse(null);
     }
 
     private boolean matches(String topic) {


### PR DESCRIPTION
## 🧷 이슈

- close #

## 🔨 작업 내용

- MQTT 디스패처 알 수 없는 토픽 예외 처리 수정
  - `MqttTopicType.from()` 에서 `orElseThrow` → `orElse(null)` 로 변경 (74ce9a5)
  - `MqttMessageDispatcher.dispatch()` 에서 null 토픽 타입 수신 시 예외 대신 debug 로그 후 무시하도록 변경 (74ce9a5)